### PR TITLE
Fixes nested resolution when no new entries are in the store

### DIFF
--- a/test/dataloader/kv_test.exs
+++ b/test/dataloader/kv_test.exs
@@ -74,6 +74,17 @@ defmodule Dataloader.KVTest do
     refute_receive(:querying)
   end
 
+  test "pending_batches? is true when the cache is already warm", %{loader: loader} do
+    loader = Dataloader.put(loader, Test, :users, "ben", @data[:users] |> List.first)
+
+    loader = Dataloader.load(loader, Test, :users, "ben")
+    assert Dataloader.pending_batches?(loader)
+
+    Dataloader.run(loader)
+
+    refute_receive(:querying)
+  end
+
   defp query(batch_key, ids, test_pid) do
     send(test_pid, :querying)
     for item <- @data[batch_key], item[:id] in ids, into: %{} do


### PR DESCRIPTION
When using in a nested resolution in absinthe, if the cache already contains all keys the resolver will never finish since pending batches will be false.

This PR adds a new flag that tracks if there has been another load that should trigger a resolve