### PR TITLE
[WIP] Ecto batch fun

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -174,7 +174,10 @@ if Code.ensure_loaded?(Ecto) do
       grouped_results = group_results(results, col)
 
       for value <- inputs do
-        Map.get(grouped_results, value)
+        case Map.get(grouped_results, value) do
+          values when is_list(values) -> Enum.reverse(values)
+          value -> value
+        end
       end
     end
 

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -157,7 +157,7 @@ if Code.ensure_loaded?(Ecto) do
       data =
         opts
         |> Keyword.put_new(:query, &query/2)
-        |> Keyword.put_new(:run_batch, &run_batch(repo, &1, &2, &3, &4))
+        |> Keyword.put_new(:run_batch, &run_batch(repo, &1, &2, &3, &4, &5))
 
       opts = Keyword.take(opts, [:timeout])
 
@@ -169,7 +169,7 @@ if Code.ensure_loaded?(Ecto) do
     Default implementation for loading a batch. Handles looking up records by
     column
     """
-    def run_batch(repo, _queryable, query, {col, inputs}, repo_opts) do
+    def run_batch(repo, _queryable, query, col, inputs, repo_opts) do
       results = load_rows(col, inputs, query, repo, repo_opts)
       grouped_results = group_results(results, col)
 
@@ -312,7 +312,7 @@ if Code.ensure_loaded?(Ecto) do
 
         repo_opts = Keyword.put(source.repo_opts, :caller, pid)
 
-        results = source.run_batch.(queryable, query, {col, inputs}, repo_opts)
+        results = source.run_batch.(queryable, query, col, inputs, repo_opts)
 
         results =
           inputs

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -367,7 +367,7 @@ if Code.ensure_loaded?(Ecto) do
 
         repo_opts = Keyword.put(source.repo_opts, :caller, pid)
 
-        cardinality_mapper = cardinality_mapper(cardinality)
+        cardinality_mapper = cardinality_mapper(cardinality, queryable)
 
         results =
           queryable
@@ -398,17 +398,17 @@ if Code.ensure_loaded?(Ecto) do
         {key, Map.new(Enum.zip(ids, results))}
       end
 
-      defp cardinality_mapper(:many) do
+      defp cardinality_mapper(:many, _) do
         fn value ->
           value
         end
       end
 
-      defp cardinality_mapper(:one) do
+      defp cardinality_mapper(:one, queryable) do
         fn
           [] -> nil
           [value] -> value
-          [_ | _] -> raise "expected one but got many"
+          other -> raise Ecto.MultipleResultsError, queryable: queryable, count: length(other)
         end
       end
     end

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -268,8 +268,10 @@ if Code.ensure_loaded?(Ecto) do
         case schema.__schema__(:association, field) do
           %{queryable: queryable} ->
             queryable
+
           %Ecto.Association.HasThrough{through: through} ->
             chase_down_queryable(through, schema)
+
           val ->
             raise """
             Valid association #{field} not found on schema #{inspect(schema)}
@@ -277,6 +279,7 @@ if Code.ensure_loaded?(Ecto) do
             """
         end
       end
+
       defp chase_down_queryable([field | fields], schema) do
         case schema.__schema__(:association, field) do
           %{queryable: queryable} ->

--- a/priv/test_repo/migrations/1_migrate_all.exs
+++ b/priv/test_repo/migrations/1_migrate_all.exs
@@ -8,6 +8,8 @@ defmodule Absinthe.Ecto.TestRepo.Migrations.MigrateAll do
 
     create table(:posts) do
       add :user_id, references(:users)
+      add :title, :string
+      add :deleted_at, :utc_datetime
     end
   end
 end

--- a/priv/test_repo/migrations/1_migrate_all.exs
+++ b/priv/test_repo/migrations/1_migrate_all.exs
@@ -11,5 +11,10 @@ defmodule Absinthe.Ecto.TestRepo.Migrations.MigrateAll do
       add :title, :string
       add :deleted_at, :utc_datetime
     end
+
+    create table(:likes) do
+      add :user_id, references(:users), null: false
+      add :post_id, references(:posts), null: false
+    end
   end
 end

--- a/test/dataloader/ecto/custom_batch_test.exs
+++ b/test/dataloader/ecto/custom_batch_test.exs
@@ -1,0 +1,76 @@
+defmodule Dataloader.Ecto.CustomBatchTest do
+  use ExUnit.Case, async: true
+
+  alias Dataloader.{User, Post}
+  import Ecto.Query
+  alias Dataloader.TestRepo, as: Repo
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+    test_pid = self()
+    source =
+      Dataloader.Ecto.new(
+        Repo,
+        [
+          query: &query(&1, &2, test_pid),
+          run_batch: &run_batch/4
+      ]
+
+      )
+
+    loader =
+      Dataloader.new()
+      |> Dataloader.add_source(Test, source)
+
+    {:ok, loader: loader}
+  end
+
+  defp query(Post, _, test_pid) do
+    send(test_pid, :querying)
+
+    Post
+    |> where([p], is_nil(p.deleted_at))
+  end
+
+  defp query(queryable, _args, test_pid) do
+    send(test_pid, :querying)
+    queryable
+  end
+
+  def run_batch(User, query, {:post_title, titles}, repo_opts) do
+    query = from u in query,
+      join: p in assoc(u, :posts),
+      where: p.title in ^titles,
+      select: {p.title, u}
+
+    results =
+      query
+      |> Repo.all(repo_opts)
+      |> Map.new
+    for title <- titles, do: Map.get(results, title)
+  end
+
+  test "basic loading of one thing", %{loader: loader} do
+    user1 = %User{username: "Ben Wilson"} |> Repo.insert!
+    user2 = %User{username: "Ben Wilson"} |> Repo.insert!
+
+    rows = [
+      %{user_id: user1.id, title: "foo"},
+      %{user_id: user2.id, title: "baz"},
+    ]
+    _ = Repo.insert_all(Post, rows)
+
+    titles = [
+      [post_title: "baz"],
+      [post_title: "foo"],
+    ]
+
+    loader =
+      loader
+      |> Dataloader.load_many(Test, User, titles)
+      |> Dataloader.run
+
+    assert [user2, user1] == Dataloader.get_many(loader, Test, User, titles)
+  end
+end

--- a/test/dataloader/ecto/custom_batch_test.exs
+++ b/test/dataloader/ecto/custom_batch_test.exs
@@ -9,14 +9,12 @@ defmodule Dataloader.Ecto.CustomBatchTest do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
 
     test_pid = self()
+
     source =
       Dataloader.Ecto.new(
         Repo,
-        [
-          query: &query(&1, &2, test_pid),
-          run_batch: &run_batch/4
-      ]
-
+        query: &query(&1, &2, test_pid),
+        run_batch: &run_batch/5
       )
 
     loader =
@@ -38,38 +36,44 @@ defmodule Dataloader.Ecto.CustomBatchTest do
     queryable
   end
 
-  def run_batch(User, query, {:post_title, titles}, repo_opts) do
-    query = from u in query,
-      join: p in assoc(u, :posts),
-      where: p.title in ^titles,
-      select: {p.title, u}
+  # get the user by post title
+  def run_batch(User, query, :post_title, titles, repo_opts) do
+    query =
+      from(
+        u in query,
+        join: p in assoc(u, :posts),
+        where: p.title in ^titles,
+        select: {p.title, u}
+      )
 
     results =
       query
       |> Repo.all(repo_opts)
-      |> Map.new
+      |> Map.new()
+
     for title <- titles, do: Map.get(results, title)
   end
 
   test "basic loading of one thing", %{loader: loader} do
-    user1 = %User{username: "Ben Wilson"} |> Repo.insert!
-    user2 = %User{username: "Ben Wilson"} |> Repo.insert!
+    user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+    user2 = %User{username: "Ben Wilson"} |> Repo.insert!()
 
     rows = [
       %{user_id: user1.id, title: "foo"},
-      %{user_id: user2.id, title: "baz"},
+      %{user_id: user2.id, title: "baz"}
     ]
+
     _ = Repo.insert_all(Post, rows)
 
     titles = [
       [post_title: "baz"],
-      [post_title: "foo"],
+      [post_title: "foo"]
     ]
 
     loader =
       loader
       |> Dataloader.load_many(Test, User, titles)
-      |> Dataloader.run
+      |> Dataloader.run()
 
     assert [user2, user1] == Dataloader.get_many(loader, Test, User, titles)
   end

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -68,11 +68,13 @@ defmodule Dataloader.EctoTest do
   end
 
   test "fancier loading works", %{loader: loader} do
-    user = %User{username: "Ben"} |> Repo.insert!
+    user = %User{username: "Ben"} |> Repo.insert!()
+
     rows = [
       %{user_id: user.id, title: "foo"},
-      %{user_id: user.id, title: "bar", deleted_at: DateTime.utc_now},
+      %{user_id: user.id, title: "bar", deleted_at: DateTime.utc_now()}
     ]
+
     {_, [%{id: post_id} | _]} = Repo.insert_all(Post, rows, returning: [:id])
 
     loader =
@@ -82,10 +84,10 @@ defmodule Dataloader.EctoTest do
 
     assert_receive(:querying)
 
-    assert %Post{} = Dataloader.get(loader, Test, Post, [id: post_id])
+    assert %Post{} = Dataloader.get(loader, Test, Post, id: post_id)
     # this shouldn't be loaded because the `query` fun should filter it out,
     # because it's deleted
-    refute Dataloader.get(loader, Test, Post, [title: "bar"])
+    refute Dataloader.get(loader, Test, Post, title: "bar")
   end
 
   test "association loading works", %{loader: loader} do

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -123,7 +123,9 @@ defmodule Dataloader.EctoTest do
       loader
       |> Dataloader.load(Test, :user, post1)
       |> Dataloader.load(Test, :user, post2)
-      |> Dataloader.run
+      |> Dataloader.run()
+
+    assert_receive(:querying)
 
     loaded_user1 =
       loader
@@ -133,8 +135,9 @@ defmodule Dataloader.EctoTest do
       loader
       |> Dataloader.get(Test, :user, post2)
 
-    assert user1 == loaded_user1
     assert user2 == loaded_user2
+
+    assert user1 == loaded_user1
   end
 
   test "association loading works", %{loader: loader} do

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -28,6 +28,7 @@ defmodule Dataloader.EctoTest do
 
     Post
     |> where([p], is_nil(p.deleted_at))
+    |> order_by(asc: :id)
   end
 
   defp query(queryable, _args, test_pid) do

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -68,7 +68,7 @@ defmodule Dataloader.EctoTest do
     refute_receive(:querying)
   end
 
-  test "fancier loading works", %{loader: loader} do
+  test "loading with cardinalty works", %{loader: loader} do
     user = %User{username: "Ben"} |> Repo.insert!()
 
     rows = [
@@ -81,7 +81,7 @@ defmodule Dataloader.EctoTest do
     loader =
       loader
       |> Dataloader.load(Test, {:one, Post}, id: post_id)
-      |> Dataloader.load(Test, {:many, Post}, title: "bar")
+      |> Dataloader.load(Test, {:one, Post}, title: "bar")
       |> Dataloader.run()
 
     assert_receive(:querying)
@@ -213,7 +213,7 @@ defmodule Dataloader.EctoTest do
     refute_receive(:querying)
   end
 
-  test "ecto not association loaded struct doesn't warm cache", %{loader: loader} do
+  test "%EctoAssociationNotLoaded{} struct doesn't warm cache", %{loader: loader} do
     user = %User{username: "Ben Wilson"} |> Repo.insert!()
 
     posts =

--- a/test/support/like.ex
+++ b/test/support/like.ex
@@ -1,0 +1,8 @@
+defmodule Dataloader.Like do
+  use Ecto.Schema
+
+  schema "likes" do
+    belongs_to(:user, Dataloader.User)
+    belongs_to(:post, Dataloader.User)
+  end
+end

--- a/test/support/post.ex
+++ b/test/support/post.ex
@@ -3,5 +3,7 @@ defmodule Dataloader.Post do
 
   schema "posts" do
     belongs_to(:user, Dataloader.User)
+    field(:title, :string)
+    field(:deleted_at, :utc_datetime)
   end
 end

--- a/test/support/post.ex
+++ b/test/support/post.ex
@@ -3,6 +3,9 @@ defmodule Dataloader.Post do
 
   schema "posts" do
     belongs_to(:user, Dataloader.User)
+    has_many(:likes, Dataloader.Like)
+    has_many(:liking_users, through: [:likes, :user])
+
     field(:title, :string)
     field(:deleted_at, :utc_datetime)
   end


### PR DESCRIPTION
Fixes #5 

This PR adds the ability to configure customizable batch loading functions to the Ecto data source. The `query` option already made it possible to add scoping conditions when looking up data. What was lacking however was the ability to accumulate values, and then supply a function that could use those values to run arbitrary SQL to do the lookup.

This PR also adds support for `through` associations.

Remaining: 

- [x] basic batch function
- [x] cardinality handling
- [x] through handling.
- [ ] docs