### PR TITLE
Bug report: Failing test for multiple loads of the same thing

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -268,6 +268,7 @@ if Code.ensure_loaded?(Ecto) do
 
       defp run_batch({{:queryable, pid, queryable, opts} = key, ids}, source) do
         {ids, _} = Enum.unzip(ids)
+        ids = Enum.uniq ids
         [primary_key] = queryable.__schema__(:primary_key)
         query = source.query.(queryable, opts)
         query = from(s in query, where: field(s, ^primary_key) in ^ids)

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -98,6 +98,13 @@ defmodule Dataloader.EctoTest do
     assert user1 == loaded_user1
   end
 
+  test "load same key multi times only adds to batches once", %{loader: loader} do
+    loader_called_once = Dataloader.load(loader, Test, User, 1)
+    loader_called_twice = Dataloader.load(loader_called_once, Test, User, 1)
+    
+    assert loader_called_once == loader_called_twice
+  end
+  
   test "association loading works", %{loader: loader} do
     user = %User{username: "Ben Wilson"} |> TestRepo.insert!()
 


### PR DESCRIPTION
When loading an entity with  Dataloader.Ecto, it is added to the internal set of batches, but calling load on the same key multiple times creates duplicates in the `batches` field

```
%Dataloader{options: [], sources: %{Test => %Dataloader.Ecto{default_params: %{}, 
options: [], query: #Function<0.91757214/2 in Dataloader.EctoTest.__ex_unit_setup_0/1>, 
repo: Dataloader.TestRepo, repo_opts: [], results: %{}, 
batches: %{{:queryable, #PID<0.303.0>, 
Dataloader.User, %{}} => [{1, 1}, {1, 1}]}}}}
```

This leads to queries like this: 

`FROM "users" AS u0 WHERE (u0."id" = ANY($1)) [[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]`

This is not generally a problem when using Dataloader for graphql queries, since each key is likely only loaded a small number of times. But it doesn't seem right!