### PR TITLE
MapSet for keys in Dataloader.KV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+.elixir_ls

--- a/lib/dataloader/kv.ex
+++ b/lib/dataloader/kv.ex
@@ -42,9 +42,8 @@ defmodule Dataloader.KV do
     def load(source, batch_key, id) do
       case fetch(source, batch_key, id) do
         :error ->
-          update_in(source.batches[batch_key], fn
-            nil -> [id]
-            ids -> [id | ids]
+          update_in(source.batches, fn batches ->
+            Map.update(batches, batch_key, MapSet.new([id]), &MapSet.put(&1, id))
           end)
 
         _ ->


### PR DESCRIPTION
Use a MapSet for keys, to keep it consistent with Dataloader.Ecto, and to allow regression testing of a bug in absinthe without needing to use Dataloader.Ecto