### PR TITLE
Added Dataloader.has_source? so registered sources can be checked

### DIFF
--- a/lib/dataloader.ex
+++ b/lib/dataloader.ex
@@ -139,6 +139,11 @@ defmodule Dataloader do
     Enum.any?(loader.sources, fn {_name, source} -> Source.pending_batches?(source) end)
   end
 
+  @spec has_source?(t, atom()) :: boolean
+  def has_source?(%{sources: sources}, source) do
+    Map.has_key?(sources, source)
+  end
+
   defp get_source(loader, source_name) do
     loader.sources[source_name] || raise "Source does not exist: #{inspect(source_name)}"
   end

--- a/test/dataloader_test.exs
+++ b/test/dataloader_test.exs
@@ -18,4 +18,14 @@ defmodule DataloaderTest do
 
     assert log =~ "boom"
   end
+
+  test "that already added sources can be identified" do
+    source = Dataloader.KV.new(fn _, ids -> Enum.with_index(ids) end)
+
+    loader =
+      Dataloader.new
+      |> Dataloader.add_source(:foo, source)
+
+    assert Dataloader.has_source?(loader, :foo)
+  end
 end


### PR DESCRIPTION
While writing some code to add multiple sources to a loader, I noticed that after a source is added subsequent calls to `add_source` would overwrite the existing source which makes sense. But I wanted to be able to be defensive about it, so I've added a function to check before potentially overwriting an existing source.