### PR TITLE
Adds a type for the run_batch option on Dataloader.Ecto.new/2

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -135,6 +135,7 @@ if Code.ensure_loaded?(Ecto) do
             {:query, query_fun}
             | {:repo_opts, Keyword.t()}
             | {:timeout, pos_integer}
+            | {:run_batch, fun()}
 
     import Ecto.Query
 


### PR DESCRIPTION
Dialyzer is failing on my project with a `Function dataloader/0 has no local return`

```elixir
  def dataloader() do
    source = Dataloader.Ecto.new(Repo, query: &query/2, run_batch: &run_batch/5)

    Dataloader.new()
    |> Dataloader.add_source(:source, source)
  end
```

I _think_ this is because we are missing a type on the `Dataloader.Ecto.new/2` function, because when I remove `run_batch` it passes...

I looked at using `batch_fun` for the type, but that wasn't the right number of params by the look of it, so I went with the simple `fun`