### PR TITLE
Demonstrate issue with strings

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -174,6 +174,13 @@ if Code.ensure_loaded?(Ecto) do
       results = load_rows(col, inputs, query, repo, repo_opts)
       grouped_results = group_results(results, col)
 
+      # This is slightly problematic because you can query by a column
+      # that is an integer providing a string (e.g. if it's an id coming from
+      # the user directly). The query part will get it from the database.
+      # Then this part will fail to do the mapping
+      #
+      # It would be great to figure out what type the column is in the database
+      # and coerce back to the type given so we can match.
       for value <- inputs do
         grouped_results
         |> Map.get(value, [])


### PR DESCRIPTION
This branch demonstrates that dataloader doesn't coerce strings to ints the way ecto does for id columns.