### PR TITLE
Demonstrate unexpected timeout behaviour when sources are slow

### DIFF
--- a/lib/dataloader.ex
+++ b/lib/dataloader.ex
@@ -88,6 +88,11 @@ defmodule Dataloader do
     if pending_batches?(dataloader) do
       fun = fn {name, source} -> {name, Source.run(source)} end
 
+      # This function behaves unexpectedly when the source times out; it drops
+      # the source! For example, if we have a single source and it times out,
+      # `pmap` silently accepts the failure and returns `[]`... which then
+      # turns our `sources` into an empty map here!
+      #
       sources =
         dataloader.sources
         |> pmap(

--- a/test/dataloader_test.exs
+++ b/test/dataloader_test.exs
@@ -18,4 +18,16 @@ defmodule DataloaderTest do
 
     assert log =~ "boom"
   end
+
+  test "fails silently and returns an empty map of sources if things timeout" do
+    source = %Dataloader.TestSource{}
+
+    dataloader =
+      Dataloader.new(timeout: 1) # Note the short timeout
+      |> Dataloader.add_source(:test, source)
+
+    new_dataloader = Dataloader.run(dataloader)
+
+    assert dataloader == new_dataloader
+  end
 end

--- a/test/support/test_source.ex
+++ b/test/support/test_source.ex
@@ -1,0 +1,19 @@
+defmodule Dataloader.TestSource do
+  defstruct [opts: [], batches: [], results: %{}]
+
+  defimpl Dataloader.Source do
+
+    def load(source, _batch_key, _item_key), do: source
+
+    def fetch(_source, _batch_key, _item_key), do: :error
+
+    def pending_batches?(_source), do: true
+
+    def put(source, _batch_key, _item_key, _item), do: source
+
+    def run(source) do
+      Process.sleep(5) # Just needs to be larger than our Dataloader timeout
+      source
+    end
+  end
+end


### PR DESCRIPTION
Hello! I'm raising this to highlight an error that took me several days to debug, as it didn't seem to make any sense. I'm more than happy to work on a fix for this, but wanted to raise this PR to give a starting point for any discussions about it, as it's a bit of a weird one :)

The test here results in the following test error:

    $ mix test
    Compiling 1 file (.ex)
    .................

      1) test fails silently and returns an empty map of sources if things timeout (DataloaderTest)
         test/dataloader_test.exs:22
         Assertion with == failed
         code:  assert dataloader == new_dataloader
         left:  %Dataloader{options: [timeout: 1], sources: %{test: %Dataloader.TestSource{batches: [], opts: [], results: %{}}}}
         right: %Dataloader{options: [timeout: 1], sources: %{}}
         stacktrace:
           test/dataloader_test.exs:31: (test)

    Finished in 0.6 seconds
    18 tests, 1 failure

    Randomized with seed 153869

This demonstrates the fact that if a `Source` times out, we don't return
an error but rather just drop it from the map of sources in our
dataloader. The problem with this is that it leads to unexpected
behaviour when we hit a timeout.

Using the example from the moduledoc:

```elixir
    # Normal setup
    source = Dataloader.Ecto.new(MyApp.Repo)
    loader = Dataloader.new |> Dataloader.add_source(:db, source)
    loader =
      loader
      |> Dataloader.load(:db, Organization, 1)
      |> Dataloader.load_many(:db, Organization, [4, 9])

    # It's entirely possible that the `Source` will timeout here, and if
    # so then this returns a loader that looks like `%Dataloader{sources: %{}}`
    loader = Dataloader.run(loader)

    # This call raises an error: `Source not found: :db`. This is
    # because there is no `:db` source anymore
    organizations = Dataloader.get_many(loader, :db, Organization, [1,4])
```

There are two issues to resolve here as I see it:

1. We shouldn't be silently dropping sources if they timeout, we should
   handle that case in `pmap` and either raise or return an appropriate
   error tuple
2. The default timeout for `Dataloader` should be slightly higher than
   the maximum default of all its sources, and it should be documented that
   if you set the timeout option, it must be higher than all sources,
   possibly even enforced