### PR TITLE
Change default dataloader timeout to be the max of its sources

### DIFF
--- a/lib/dataloader.ex
+++ b/lib/dataloader.ex
@@ -108,15 +108,11 @@ defmodule Dataloader do
   defp dataloader_timeout(dataloader) do
     max_source_timeout =
       dataloader.sources
-      |> Enum.map(fn {_, source} -> source_timeout(source) end)
+      |> Enum.map(fn {_, source} -> Source.timeout(source) end)
       |> Enum.max()
 
     (max_source_timeout || @default_timeout) + :timer.seconds(1)
   end
-
-  defp source_timeout(%{opts: opts}), do: opts[:timeout]
-  defp source_timeout(%{options: options}), do: options[:timeout]
-  defp source_timeout(_source_without_options), do: @default_timeout
 
   @spec get(t, source_name, any, any) :: any | no_return()
   def get(loader, source, batch_key, item_key) do

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -294,6 +294,10 @@ if Code.ensure_loaded?(Ecto) do
         batches != %{}
       end
 
+      def timeout(%{options: options}) do
+        options[:timeout]
+      end
+
       defp chase_down_queryable([field], schema) do
         case schema.__schema__(:association, field) do
           %{queryable: queryable} ->

--- a/lib/dataloader/kv.ex
+++ b/lib/dataloader/kv.ex
@@ -79,5 +79,9 @@ defmodule Dataloader.KV do
     def pending_batches?(source) do
       source.batches != %{}
     end
+
+    def timeout(%{opts: opts}) do
+      opts[:timeout]
+    end
   end
 end

--- a/lib/dataloader/source.ex
+++ b/lib/dataloader/source.ex
@@ -33,4 +33,13 @@ defprotocol Dataloader.Source do
   """
   @spec put(t, batch_key, item_key, term) :: t
   def put(source, batch_key, item_key, item)
+
+  @doc """
+  Returns the timeout (in ms) for the source.
+
+  This is important for ensuring the dataloader obeys the timeouts when running
+  multiple sources concurrently
+  """
+  @spec timeout(t) :: number
+  def timeout(source)
 end


### PR DESCRIPTION
Without this, it's easy for people to configure a large timeout on a
source and not realise that the supervising process has killed it
prematurely by exiting on a default 15_000 timeout.

Note that this throws away the concept of setting a timeout on the
`Dataloader` level. I initially implemented this allowing the timeout
to be set, but this ultimately makes no sense. The only consequence of
allowing people to set a lower timeout on the `Dataloader` than exists
on their `Source` is to open ourselves up to a whole new class of bugs,
there is no benefit to doing this. So just don't allow it :).

**NOTE**: This relates directly to the bug raised in https://github.com/absinthe-graphql/dataloader/pull/35 - with this, I would never have hit that issue