### PR TITLE
Make use of Dataloader.Ecto.batch_fun() within Dataloader.Ecto.opt() typespec

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -164,7 +164,7 @@ if Code.ensure_loaded?(Ecto) do
             {:query, query_fun}
             | {:repo_opts, Keyword.t()}
             | {:timeout, pos_integer}
-            | {:run_batch, fun()}
+            | {:run_batch, batch_fun()}
 
     import Ecto.Query
 


### PR DESCRIPTION
This is a simple fix to the typespecs in `Ecto.Dataloader`. While investigating some dialyzer errors within our own application we noticed that the `Dataloader.Ecto.opt()` type was using a generic `fun()` type for it's `run_batch` key, rather than the `batch_fun()` type specifically defined for it.