### PR TITLE
[PROPOSAL] Expose errors when getting data in Dataloader

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -234,8 +234,7 @@ if Code.ensure_loaded?(Ecto) do
           source.batches
           |> Dataloader.pmap(
             &run_batch(&1, source),
-            timeout: source.options[:timeout] || 15_000,
-            tag: "Ecto batch"
+            timeout: source.options[:timeout] || 15_000
           )
 
         results =

--- a/lib/dataloader/source.ex
+++ b/lib/dataloader/source.ex
@@ -17,7 +17,7 @@ defprotocol Dataloader.Source do
   @doc """
   Fetch the result found under the given batch and item keys.
   """
-  @spec fetch(t, batch_key, item_key) :: {:ok, term} | :error
+  @spec fetch(t, batch_key, item_key) :: {:ok, term} | {:error, term}
   def fetch(source, batch_key, item_key)
 
   @doc """

--- a/test/dataloader/kv_test.exs
+++ b/test/dataloader/kv_test.exs
@@ -1,5 +1,6 @@
 defmodule Dataloader.KVTest do
   use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
 
   @data [
     users: [
@@ -69,11 +70,104 @@ defmodule Dataloader.KVTest do
     refute_receive(:querying)
   end
 
+  test "raises with when fetching values that failed to load", %{loader: loader} do
+    user_ids = ~w(ben bruce something_that_errors)
+
+    log =
+      capture_log(fn ->
+        loader =
+          loader
+          |> Dataloader.load_many(Test, :users, user_ids)
+          |> Dataloader.run()
+
+        assert_raise Dataloader.GetError,
+                     ~r/Failed when fetching key 'something_that_errors'/,
+                     fn ->
+                       loader
+                       |> Dataloader.get(Test, :users, "something_that_errors")
+                     end
+
+        assert_raise Dataloader.GetError,
+                     ~r/Failed when fetching key 'something_that_errors'/,
+                     fn ->
+                       loader
+                       |> Dataloader.get_many(Test, :users, ~w(something_that_errors))
+                     end
+
+        assert_raise Dataloader.GetError,
+                     ~r/Failed when fetching key 'something_that_errors'/,
+                     fn ->
+                       loader
+                       |> Dataloader.get_many(Test, :users, user_ids)
+                     end
+      end)
+
+    assert log =~ "Failed when fetching key 'something_that_errors'"
+  end
+
+  test "batches that succeed can still return data if there are failures in other batches", %{
+    loader: loader
+  } do
+    user_ids = ~w(ben bruce)
+
+    log =
+      capture_log(fn ->
+        loader =
+          loader
+          |> Dataloader.load_many(Test, :users, user_ids)
+          |> Dataloader.load(Test, :books, "something_that_errors")
+          |> Dataloader.run()
+
+        loaded_users =
+          loader
+          |> Dataloader.get_many(Test, :users, user_ids)
+
+        assert @data[:users] == loaded_users
+
+        assert_raise Dataloader.GetError,
+                     ~r/Failed when fetching key 'something_that_errors'/,
+                     fn ->
+                       loader
+                       |> Dataloader.get(Test, :books, "something_that_errors")
+                     end
+      end)
+
+    assert log =~ "Failed when fetching key 'something_that_errors'"
+  end
+
+  test "raises default error if not loaded yet", %{loader: loader} do
+    assert_raise Dataloader.GetError, ~r/Failed to get data/, fn ->
+      loader
+      |> Dataloader.get(Test, :users, "doesn't exist")
+    end
+  end
+
+  test "returns nil for a key if we've loaded it but it can't be found", %{loader: loader} do
+    not_found_users =
+      loader
+      |> Dataloader.load(Test, :users, "not_found")
+      |> Dataloader.run()
+      |> Dataloader.get_many(Test, :users, ~w(not_found))
+
+    assert not_found_users == [nil]
+  end
+
   defp query(batch_key, ids, test_pid) do
     send(test_pid, :querying)
 
-    for item <- @data[batch_key], item[:id] in ids, into: %{} do
-      {item[:id], item}
+    for id <- ids, into: %{} do
+      query(batch_key, id)
     end
+  end
+
+  defp query(_batch_key, "something_that_errors"),
+    do: raise("Failed when fetching key 'something_that_errors'")
+
+  defp query(batch_key, id) do
+    item =
+      @data[batch_key]
+      |> Enum.find(fn data -> data[:id] == id end)
+
+    {id, item}
   end
 end

--- a/test/dataloader_test.exs
+++ b/test/dataloader_test.exs
@@ -2,20 +2,67 @@ defmodule DataloaderTest do
   use ExUnit.Case
   import ExUnit.CaptureLog
 
-  test "pmap won't die if an exception in a child happens" do
-    log =
-      capture_log(fn ->
-        assert %{2 => 4} ==
-                 Dataloader.pmap(
-                   [1, 2],
-                   fn
-                     1 -> raise "boom"
-                     2 -> {2, 4}
-                   end,
-                   []
-                 )
-      end)
+  describe "run/1" do
+    test "returns an ok tuple on success" do
+      source = %Dataloader.TestSource{
+        run: fn _source ->
+          function_that_succeeds = fn
+            1 -> "hello"
+            2 -> "bye"
+          end
 
-    assert log =~ "boom"
+          Dataloader.pmap([1, 2], function_that_succeeds)
+        end
+      }
+
+      dataloader =
+        Dataloader.new()
+        |> Dataloader.add_source(:test, source)
+
+      %{sources: sources} = Dataloader.run(dataloader)
+
+      assert %{test: %{1 => {:ok, "hello"}, 2 => {:ok, "bye"}}} = sources
+    end
+
+    test "returns an error tuple on failure" do
+      source = %Dataloader.TestSource{
+        run: fn _source ->
+          function_that_raises = fn :this_will_raise -> raise "hell" end
+          Dataloader.pmap([:this_will_raise], function_that_raises)
+        end
+      }
+
+      dataloader =
+        Dataloader.new()
+        |> Dataloader.add_source(:test, source)
+
+      log =
+        capture_log(fn ->
+          %{sources: sources} = Dataloader.run(dataloader)
+
+          assert %{test: %{this_will_raise: {:error, error}}} = sources
+
+          assert inspect(error) =~ ~s(%RuntimeError{message: "hell"})
+        end)
+
+      assert log =~ "hell"
+    end
+
+    test "returns an error if the source times out" do
+      source = %Dataloader.TestSource{
+        run: fn _source ->
+          function_that_times_out = fn :this_will_timeout -> Process.sleep(:timer.seconds(5)) end
+          Dataloader.pmap([:this_will_timeout], function_that_times_out, timeout: 1)
+        end
+      }
+
+      dataloader =
+        Dataloader.new()
+        |> Dataloader.add_source(:test, source)
+
+      %{sources: sources} = Dataloader.run(dataloader)
+
+      assert %{test: %{this_will_timeout: {:error, :timeout}}} = sources
+    end
   end
 end

--- a/test/support/test_source.ex
+++ b/test/support/test_source.ex
@@ -1,0 +1,37 @@
+defmodule Dataloader.TestSource do
+  @moduledoc """
+  This implements a simple `Source` that can be initialised with any function
+  as it's `fun`, which it will then get called when `run/1` does. This should
+  allow us to test `Dataloader.run/1`
+
+  An example usage:
+
+      ```elixir
+      source = %Dataloader.TestSource{run: fn _ -> "HELLO" end}
+
+      dataloader =
+        Dataloader.new()
+        |> Dataloader.add_source(:test, source)
+
+      %{sources: sources} = Dataloader.run(dataloader)
+
+      assert sources == %{test: "HELLO"}
+      ```
+  """
+
+  defstruct run: nil, timeout: :timer.seconds(15), data: []
+
+  defimpl Dataloader.Source do
+    def load(source, _batch_key, _item_key), do: source
+
+    def fetch(_source, _batch_key, _item_key), do: :error
+
+    def pending_batches?(_source), do: true
+
+    def put(source, _batch_key, _item_key, _item), do: source
+
+    def run(source), do: source.run.(source)
+
+    def timeout(source), do: source.timeout
+  end
+end


### PR DESCRIPTION
**NOTE** - This is *very* much WIP, I'm pushing this commit up in order to get some
feedback on it before carrying on. Please don't review this as production-ready, as it's not and half the tests are failing :smile: 

## Summary

Currently, there is no explicit handling of errors in `Dataloader` if we have (for example) a third party timeout, a database error or simple match error. The error is logged, but not otherwise exposed. This has a side-effect of potentially dropping `Source` structs and leading to unexpected  errors where despite loading a source, Dataloader will raise with `Source not found`. I initially highlighted this in #35. 

## Possible approaches

As I see it, there are three possible approaches we can take when dealing with the errors here:

1. **Return `nil` on error** - current `master` behaviour, which has the shortcoming of hiding errors in production environments and potentially raising misleading errors (e.g. #35)
2. **Raise on error** - that is the approach taken here, as I expect this would be the least breaking change; the upgrade path for most people would involve being aware that errors may now get raised. The only complex changes may arise for people who've implemented their own `Source` modules.
3. **Change `get` and `get_many` to return `:ok`/`:error` tuples** (a.k.a. let the developer decide) - This would be a simple extension of (2), as this is largely how I've implemented this internally. However, it's a more significant breaking change as anyone using `Dataloader` as they'd need to change everything to handle tuples instead of raw values.

It could be that we want a configurable approach here, but I'd be tempted to shy away from that simply because configuration will add complexity.

## Where to raise on error

There are two places we could legitimately raise an error, either when we `load` the data or when we `get` the data. I've taken the approach of storing `:ok`/`:error` tuples internally on `load`, and then raising on `get`. My assumption here being that it's possible we load data we don't fetch, in which case the errors are irrelevant.

## Work done so far

I've essentially done the following:

1. Refactor `pmap` to return `:ok`/`:error` tuples instead of swallowing errors
2. Refactor `Dataloader.run/1` to manage the new `pmap`
2. Added "error" tests into the `KV` class and got them passing
3. Added some additional comments with thoughts on tidying up and possible further changes

I chose to implement the changes in `KV` rather than `Ecto` because it was a simpler interface and should demonstrate how sources can be updated to get the desired effect. I wanted to get feedback on the approach before carrying on in case I'm just chasing myself down a rabbit hole, so figured this was a good time to push something up.

### Things to look at in this PR

Specifically, check out the tests; they outline the behaviour changes best. Also I'd like some validation on my comments around `pmap` please. I'm fairly certain it should be made less generic and behave differently depending on whether we're calling from `Dataloader.run` or a `Source.run`.

## Next steps

* Decide on approach
* Refactor or update current implementation where necessary
* Extend this to `Ecto`
* Profit