### PR TITLE
Add error handling when sources fail to load data

### DIFF
--- a/lib/dataloader.ex
+++ b/lib/dataloader.ex
@@ -56,6 +56,17 @@ defmodule Dataloader do
   * `get_policy` - This configures how the dataloader will behave when fetching
     data which may have errored when we tried  to `load` it.
 
+  These can be set as part of the `new/1` call. So, for example, to
+  configure a dataloader that returns `nil` on error with a 5s timeout:
+
+  ```elixir
+  loader =
+    Dataloader.new(
+      get_policy: :return_nil_on_error,
+      timeout: :timer.seconds(5)
+    )
+  ```
+
   ### `get_policy`
 
   There are three implemented behaviours for this:
@@ -69,14 +80,6 @@ defmodule Dataloader do
     depending on a successful or failed load, allowing for more fine-grained
     error handling if required
 
-  These can be configured on a global way by configuring in your config.exs
-  file, e.g. to configure it to return nil on error:
-
-      config :dataloader,
-        get_policy: :return_nil_on_error
-
-  Alternatively, these can be set on individual `Dataloader` structs when
-  calling `new/1`
   """
   defstruct sources: %{},
             options: []
@@ -95,7 +98,7 @@ defmodule Dataloader do
   @default_timeout 15_000
   def default_timeout, do: @default_timeout
 
-  @default_get_policy Application.get_env(:dataloader, :get_policy, :raise_on_error)
+  @default_get_policy :raise_on_error
 
   @spec new([option]) :: t
   def new(opts \\ []) do

--- a/lib/dataloader.ex
+++ b/lib/dataloader.ex
@@ -1,4 +1,9 @@
 defmodule Dataloader do
+  defmodule GetError do
+    defexception message:
+                   "Failed to get data, this may mean it has not been loaded, see Dataloader documentation for more info."
+  end
+
   @moduledoc """
   # Dataloader
 
@@ -40,6 +45,38 @@ defmodule Dataloader do
   have a different source used for each context. This provides an easy way to
   enforce data access rules within each context. See the `DataLoader.Ecto`
   moduledocs for more details
+
+  ## Options
+
+  There are two configuration options:
+
+  * `timeout` - The maximum timeout to wait for running a source, defaults to
+    1s more than the maximum timeout of all added sources. Set with care,
+    timeouts should really only be set on sources.
+  * `get_policy` - This configures how the dataloader will behave when fetching
+    data which may have errored when we tried  to `load` it.
+
+  ### `get_policy`
+
+  There are three implemented behaviours for this:
+
+  * `raise_on_error` (default)- If successful, calling `get/4` or `get_many/4`
+    will return the value. If there was an exception when trying to load any of
+    the data, it will raise that exception
+  * `return_nil_on_error` - Behaves similar to `raise_on_error` but will just
+    return `nil` instead of `raising`. It will still log errors
+  * `tuples` - This will return `{:ok, value}`/`{:error, reason}` tuples
+    depending on a successful or failed load, allowing for more fine-grained
+    error handling if required
+
+  These can be configured on a global way by configuring in your config.exs
+  file, e.g. to configure it to return nil on error:
+
+      config :dataloader,
+        get_policy: :return_nil_on_error
+
+  Alternatively, these can be set on individual `Dataloader` structs when
+  calling `new/1`
   """
   defstruct sources: %{},
             options: []
@@ -52,13 +89,22 @@ defmodule Dataloader do
           options: [option]
         }
 
-  @type option :: {:timeout, pos_integer}
+  @type option :: {:timeout, pos_integer} | {:get_policy, atom()}
   @type source_name :: any
 
   @default_timeout 15_000
+  def default_timeout, do: @default_timeout
+
+  @default_get_policy Application.get_env(:dataloader, :get_policy, :raise_on_error)
 
   @spec new([option]) :: t
-  def new(opts \\ []), do: %__MODULE__{options: opts}
+  def new(opts \\ []) do
+    opts =
+      [get_policy: @default_get_policy]
+      |> Keyword.merge(opts)
+
+    %__MODULE__{options: opts}
+  end
 
   @spec add_source(t, source_name, Dataloader.Source.t()) :: t
   def add_source(%{sources: sources} = loader, name, source) do
@@ -91,12 +137,15 @@ defmodule Dataloader do
       fun = fn {name, source} -> {name, Source.run(source)} end
 
       sources =
-        dataloader.sources
-        |> pmap(
+        async_safely(__MODULE__, :run_tasks, [
+          dataloader.sources,
           fun,
-          tag: "Source",
-          timeout: dataloader_timeout(dataloader)
-        )
+          [timeout: dataloader_timeout(dataloader)]
+        ])
+        |> Enum.map(fn
+          {_source, {:ok, {name, source}}} -> {name, source}
+          {_source, {:error, reason}} -> {:error, reason}
+        end)
         |> Map.new()
 
       %{dataloader | sources: sources}
@@ -115,26 +164,32 @@ defmodule Dataloader do
   end
 
   @spec get(t, source_name, any, any) :: any | no_return()
-  def get(loader, source, batch_key, item_key) do
+  def get(loader = %Dataloader{options: options}, source, batch_key, item_key) do
     loader
     |> get_source(source)
     |> Source.fetch(batch_key, item_key)
-    |> do_get
+    |> do_get(options[:get_policy])
   end
 
-  defp do_get({:ok, val}), do: val
-  defp do_get(:error), do: nil
-
   @spec get_many(t, source_name, any, any) :: [any] | no_return()
-  def get_many(loader, source, batch_key, item_keys) when is_list(item_keys) do
+  def get_many(loader = %Dataloader{options: options}, source, batch_key, item_keys)
+      when is_list(item_keys) do
     source = get_source(loader, source)
 
     for key <- item_keys do
       source
       |> Source.fetch(batch_key, key)
-      |> do_get
+      |> do_get(options[:get_policy])
     end
   end
+
+  defp do_get({:ok, val}, :raise_on_error), do: val
+  defp do_get({:ok, val}, :return_nil_on_error), do: val
+  defp do_get({:ok, val}, :tuples), do: {:ok, val}
+
+  defp do_get({:error, reason}, :raise_on_error), do: raise(Dataloader.GetError, inspect(reason))
+  defp do_get({:error, _reason}, :return_nil_on_error), do: nil
+  defp do_get({:error, reason}, :tuples), do: {:error, reason}
 
   def put(loader, source_name, batch_key, item_key, result) do
     source =
@@ -154,16 +209,28 @@ defmodule Dataloader do
     loader.sources[source_name] || raise "Source does not exist: #{inspect(source_name)}"
   end
 
-  @doc false
-  def pmap(items, fun, opts) do
-    options = [
-      timeout: opts[:timeout] || @default_timeout,
-      on_timeout: :kill_task
-    ]
+  @doc """
+  This is a helper method to run a set of async tasks in a separate supervision
+  tree which:
 
+  1. Is run by a supervisor linked to the main process. This ensures any async
+     tasks will get killed if the main process is killed.
+  2. Spawns a separate task which traps exits for running the provided
+     function. This ensures we will always have some output, but are not
+     setting `:trap_exit` on the main process.
+
+  **NOTE**: The provided `fun` must accept a `Task.Supervisor` as its first
+  argument, as this function will prepend the relevant supervisor to `args`
+
+  See `run_tasks/4` for an example of a `fun` implementation, this will return
+  whatever that returns.
+  """
+  @spec async_safely(module(), atom(), list()) :: any()
+  def async_safely(mod, fun, args \\ []) do
     # This supervisor exists to help ensure that the spawned tasks will die as
     # promptly as possible if the current process is killed.
-    {:ok, task_super} = Task.Supervisor.start_link([])
+    {:ok, task_supervisor} = Task.Supervisor.start_link([])
+    args = [task_supervisor | args]
 
     # The intermediary task is spawned here so that the `:trap_exit` flag does
     # not lead to rogue behaviour within the current process. This could happen
@@ -176,19 +243,70 @@ defmodule Dataloader do
         # back no matter what.
         Process.flag(:trap_exit, true)
 
-        task_super
-        |> Task.Supervisor.async_stream(items, fun, options)
-        |> Enum.reduce(%{}, fn
-          {:ok, {key, value}}, results ->
-            Map.put(results, key, value)
-
-          _, results ->
-            results
-        end)
+        apply(mod, fun, args)
       end)
 
     # The infinity is safe here because the internal
     # tasks all have their own timeout.
     Task.await(task, :infinity)
+  end
+
+  @doc ~S"""
+  This helper function will call `fun` on all `items` asynchronously, returning
+  a map of `:ok`/`:error` tuples, keyed off the `items`. For example:
+
+      iex> {:ok, task_supervisor} = Task.Supervisor.start_link([])
+      ...> Dataloader.run_tasks(task_supervisor, [1,2,3], fn x -> x * x end, [])
+      %{
+        1 => {:ok, 1},
+        2 => {:ok, 4},
+        3 => {:ok, 9}
+      }
+
+  Similarly, for errors:
+
+      iex> {:ok, task_supervisor} = Task.Supervisor.start_link([])
+      ...> Dataloader.run_tasks(task_supervisor, [1,2,3], fn _x -> Process.sleep(5) end, [timeout: 1])
+      %{
+        1 => {:error, :timeout},
+        2 => {:error, :timeout},
+        3 => {:error, :timeout}
+      }
+  """
+  @spec run_tasks(Task.Supervisor.t(), list(), fun(), keyword()) :: map()
+  def run_tasks(task_supervisor, items, fun, opts \\ []) do
+    task_opts = [
+      timeout: opts[:timeout] || @default_timeout,
+      on_timeout: :kill_task
+    ]
+
+    results =
+      task_supervisor
+      |> Task.Supervisor.async_stream(items, fun, task_opts)
+      |> Enum.map(fn
+        {:ok, result} -> {:ok, result}
+        {:exit, reason} -> {:error, reason}
+      end)
+
+    Enum.zip(items, results)
+    |> Map.new()
+  end
+
+  @doc """
+  This function is depreacted in favour of `async_safely/3`
+
+  This used to be used by both the `Dataloader` module for running multiple
+  source queries concurrently, and the `KV` and `Ecto` sources to actually run
+  separate batch fetches (e.g. for `Posts` and `Users` at the same time).
+
+  The problem was that the behaviour between the sources and the parent
+  `Dataloader` was actually slightly different. The `Dataloader`-specific
+  behaviour has been pulled out into `run_tasks/4`
+
+  Please use `async_safely` instead of this for fetching data from sources
+  """
+  @spec pmap(list(), fun(), keyword()) :: map()
+  def pmap(items, fun, opts \\ []) do
+    async_safely(__MODULE__, :run_tasks, [items, fun, opts])
   end
 end

--- a/lib/dataloader/source.ex
+++ b/lib/dataloader/source.ex
@@ -17,7 +17,7 @@ defprotocol Dataloader.Source do
   @doc """
   Fetch the result found under the given batch and item keys.
   """
-  @spec fetch(t, batch_key, item_key) :: {:ok, term} | :error
+  @spec fetch(t, batch_key, item_key) :: {:ok, term} | {:error, term}
   def fetch(source, batch_key, item_key)
 
   @doc """

--- a/test/dataloader_test.exs
+++ b/test/dataloader_test.exs
@@ -2,20 +2,242 @@ defmodule DataloaderTest do
   use ExUnit.Case
   import ExUnit.CaptureLog
 
-  test "pmap won't die if an exception in a child happens" do
-    log =
-      capture_log(fn ->
-        assert %{2 => 4} ==
-                 Dataloader.pmap(
-                   [1, 2],
-                   fn
-                     1 -> raise "boom"
-                     2 -> {2, 4}
-                   end,
-                   []
-                 )
-      end)
+  doctest Dataloader
 
-    assert log =~ "boom"
+  @data [
+    users: [
+      [id: "ben", username: "Ben Wilson"],
+      [id: "bruce", username: "Bruce Williams"]
+    ]
+  ]
+
+  defp query(batch_key, ids = %MapSet{}) do
+    for id <- ids, into: %{} do
+      query(batch_key, id)
+    end
+  end
+
+  defp query(_batch_key, "explode"), do: raise("hell")
+
+  defp query(batch_key, id) do
+    item =
+      @data[batch_key]
+      |> Enum.find(fn data -> data[:id] == id end)
+
+    {id, item}
+  end
+
+  setup do
+    loader =
+      Dataloader.new()
+      |> Dataloader.add_source(:test, Dataloader.KV.new(&query(&1, &2)))
+
+    [loader: loader]
+  end
+
+  describe "setting defaults" do
+    test "new/1 sets an appropriate default get_policy" do
+      loader = Dataloader.new()
+
+      assert loader.options[:get_policy] == :raise_on_error
+
+      loader = Dataloader.new(other: :option)
+
+      assert loader.options[:get_policy] == :raise_on_error
+    end
+
+    test "new/1 can override the default policy" do
+      loader = Dataloader.new(get_policy: :foo)
+
+      assert loader.options[:get_policy] == :foo
+    end
+  end
+
+  describe "get methods when configured to raise an error" do
+    test "get/4 returns a value when successful", %{loader: loader} do
+      result =
+        loader
+        |> Dataloader.load(:test, :users, "ben")
+        |> Dataloader.run()
+        |> Dataloader.get(:test, :users, "ben")
+
+      assert result == [id: "ben", username: "Ben Wilson"]
+    end
+
+    test "get_many/4 returns a value when successful", %{loader: loader} do
+      result =
+        loader
+        |> Dataloader.load_many(:test, :users, ["ben", "bruce"])
+        |> Dataloader.run()
+        |> Dataloader.get_many(:test, :users, ["ben", "bruce"])
+
+      assert result == [
+               [id: "ben", username: "Ben Wilson"],
+               [id: "bruce", username: "Bruce Williams"]
+             ]
+    end
+
+    test "get/4 raises an exception when there was an error loading the data", %{loader: loader} do
+      log =
+        capture_log(fn ->
+          loader =
+            loader
+            |> Dataloader.load(:test, :users, "explode")
+            |> Dataloader.run()
+
+          assert_raise Dataloader.GetError, ~r/hell/, fn ->
+            loader
+            |> Dataloader.get(:test, :users, "explode")
+          end
+        end)
+
+      assert log =~ "hell"
+    end
+
+    test "get_many/4 raises an exception when there was an error loading the data", %{
+      loader: loader
+    } do
+      log =
+        capture_log(fn ->
+          loader =
+            loader
+            |> Dataloader.load_many(:test, :users, ["explode"])
+            |> Dataloader.run()
+
+          assert_raise Dataloader.GetError, ~r/hell/, fn ->
+            loader
+            |> Dataloader.get_many(:test, :users, ["explode"])
+          end
+        end)
+
+      assert log =~ "hell"
+    end
+  end
+
+  describe "get methods when configured to return `nil` on error" do
+    setup %{loader: loader} do
+      [loader: %{loader | options: [get_policy: :return_nil_on_error]}]
+    end
+
+    test "get/4 returns a value when successful", %{loader: loader} do
+      result =
+        loader
+        |> Dataloader.load(:test, :users, "ben")
+        |> Dataloader.run()
+        |> Dataloader.get(:test, :users, "ben")
+
+      assert result == [id: "ben", username: "Ben Wilson"]
+    end
+
+    test "get_many/4 returns values when successful", %{loader: loader} do
+      result =
+        loader
+        |> Dataloader.load_many(:test, :users, ["ben", "bruce"])
+        |> Dataloader.run()
+        |> Dataloader.get_many(:test, :users, ["ben", "bruce"])
+
+      assert result == [
+               [id: "ben", username: "Ben Wilson"],
+               [id: "bruce", username: "Bruce Williams"]
+             ]
+    end
+
+    test "get/4 logs the exception and returns `nil` when there was an error loading the data", %{
+      loader: loader
+    } do
+      log =
+        capture_log(fn ->
+          result =
+            loader
+            |> Dataloader.load(:test, :users, "explode")
+            |> Dataloader.run()
+            |> Dataloader.get(:test, :users, "explode")
+
+          assert result |> is_nil()
+        end)
+
+      assert log =~ "hell"
+    end
+
+    test "get_many/4 logs the exception and returns `nil` when there was an error loading the data",
+         %{loader: loader} do
+      log =
+        capture_log(fn ->
+          result =
+            loader
+            |> Dataloader.load_many(:test, :users, ["ben", "explode"])
+            |> Dataloader.run()
+            |> Dataloader.get_many(:test, :users, ["ben", "explode"])
+
+          assert result == [nil, nil]
+        end)
+
+      assert log =~ "hell"
+    end
+  end
+
+  describe "get methods when configured to return ok/error tuples" do
+    setup %{loader: loader} do
+      [loader: %{loader | options: [get_policy: :tuples]}]
+    end
+
+    test "get/4 returns an {:ok, value} tuple when successful", %{loader: loader} do
+      result =
+        loader
+        |> Dataloader.load(:test, :users, "ben")
+        |> Dataloader.run()
+        |> Dataloader.get(:test, :users, "ben")
+
+      assert result == {:ok, [id: "ben", username: "Ben Wilson"]}
+    end
+
+    test "get_many/4 returns a list of {:ok, value} tuples when successful", %{loader: loader} do
+      result =
+        loader
+        |> Dataloader.load_many(:test, :users, ["ben", "bruce"])
+        |> Dataloader.run()
+        |> Dataloader.get_many(:test, :users, ["ben", "bruce"])
+
+      assert result == [
+               {:ok, [id: "ben", username: "Ben Wilson"]},
+               {:ok, [id: "bruce", username: "Bruce Williams"]}
+             ]
+    end
+
+    test "get/4 returns an {:error, reason} tuple when there was an error loading the data", %{
+      loader: loader
+    } do
+      log =
+        capture_log(fn ->
+          result =
+            loader
+            |> Dataloader.load(:test, :users, "explode")
+            |> Dataloader.run()
+            |> Dataloader.get(:test, :users, "explode")
+
+          assert {:error, {%RuntimeError{message: "hell"}, _stacktrace}} = result
+        end)
+
+      assert log =~ "hell"
+    end
+
+    test "get_many/4 returns a list of {:error, reason} tuples when there was an error loading the data",
+         %{loader: loader} do
+      log =
+        capture_log(fn ->
+          result =
+            loader
+            |> Dataloader.load_many(:test, :users, ["ben", "explode"])
+            |> Dataloader.run()
+            |> Dataloader.get_many(:test, :users, ["ben", "explode"])
+
+          assert [
+                   {:error, {%RuntimeError{message: "hell"}, _stacktrace1}},
+                   {:error, {%RuntimeError{message: "hell"}, _stacktrace2}}
+                 ] = result
+        end)
+
+      assert log =~ "hell"
+    end
   end
 end


### PR DESCRIPTION
I'm raising this following an initial PR (https://github.com/absinthe-graphql/dataloader/pull/39) a couple of weeks ago. I've had a couple of other guys take a look internally before raising and so hopefully it should pretty much be there :crossed_fingers:. I ended up implementing all three ways mentioned in #39  (as this was trivial in the end; see the `do_get/2` method). Happy to make changes, rename stuff etc if you want :smile:!

Previously, if any errors occurred when a source tried to load data,
this would get logged and a `nil` would get returned.

The danger of this is that this means errors may go unnoticed in
production environments (e.g. timeouts to third parties) as a `nil`
result may be a reasonable one depending on the `Source` and data.

This provides two additional configurable methods of error handling:

* `:raise_on_error` - this will raise a `Datlaoader.GetError` when one
  of the `get` methods are called. This is now the default behaviour
  for handling errors
* `:tuples` - this changes the `get/4`/`get_many/4` methods to return
  `:ok`/`:error` tuples instead of just the value. This frees up the
  caller to handle errors any way they see fit