### PR TITLE
Fixes memory issue when querying large amounts of data.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 elixir 1.7.2-otp-21
+erlang 21.0.8

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -400,15 +400,15 @@ if Code.ensure_loaded?(Ecto) do
         {key, default_params}
       end
 
-      def run_batches(task_supervisor, source) do
+      def run_batches(source) do
         options = [
           timeout: source.options[:timeout] || Dataloader.default_timeout(),
           on_timeout: :kill_task
         ]
 
         results =
-          task_supervisor
-          |> Task.Supervisor.async_stream(source.batches, &run_batch(&1, source), options)
+          source.batches
+          |> Task.async_stream(&run_batch(&1, source), options)
           |> Enum.map(fn
             {:ok, {_key, result}} -> {:ok, result}
             {:exit, reason} -> {:error, reason}


### PR DESCRIPTION
We found when querying for lots of data that the RAM would increase
unbounded because the spawned supervisors were never shut down. This meant, even if we paginated the queries, the RAM usage
would steadily increase, until the whole request had finished.

Should close #47 