### PR TITLE
Add source url in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule Dataloader.Mixfile do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       aliases: aliases(),
+      source_url: "https://github.com/absinthe-graphql/dataloader",
       docs: [
         main: "Dataloader",
         source_ref: "v#{@version}",


### PR DESCRIPTION
Added the source url in mix.exs so that the generated docs link to the sourcefiles.