### PR TITLE
[WIP] Source protocol load_many

### DIFF
--- a/lib/dataloader/source.ex
+++ b/lib/dataloader/source.ex
@@ -9,6 +9,13 @@ defprotocol Dataloader.Source do
   def load(source, batch_key, item_key)
 
   @doc """
+  Enqueue many items to be loaded under a given batch
+  Do not queue items that are already loaded
+  """
+  @spec load_many(t, batch_key, [item_key]) :: t
+  def load_many(source, batch_key, item_keys)
+
+  @doc """
   Run any batches queued up for this source.
   """
   @spec run(t) :: t
@@ -19,6 +26,9 @@ defprotocol Dataloader.Source do
   """
   @spec fetch(t, batch_key, item_key) :: {:ok, term} | {:error, term}
   def fetch(source, batch_key, item_key)
+
+  @spec fetch_many(t, batch_key, [item_key]) :: {:ok, [term]} | {:error, term}
+  def fetch_many(source, batch_key, item_keys)
 
   @doc """
   Determine if there are any batches that have not yet been run.


### PR DESCRIPTION
In response to really slow load times and the conversation in slack I'm submitting this PR as WIP. It's not nearly finished. 

Basically I need some help. To get the specs to pass there is behaviour that I'm not really sure how to ensure during a batch operation.

Here is the last comment on the thread for context:

I’m going to work on a PR today. I make heavy use of dataloaders in my resolvers. The `load_many` was ultimately the cause. The `DataLoader.Source` protocol does not allow for load many, so the source is forced to treat every item individually via `load` rather than taking care of a batch operation efficiently within the source. I’ll provide numbers in the PR but the difference I noticed last night was around 20s for 500 top level items (+combination of load one and load manys) by having more efficient batch operations. The load/load_many calls were all >1ms with many of the `load_many` calls running into the 100s of ms depending on the number of items before the patch and all < 1ms after the patch. I think from memory my biggest call to load many clocks in at about 180 ids which was well over 200ms just for the load_many call.

```
[(x500)
     load_one
     load_many (between 50-180 ids per top level record)
     load_one 
  ]
```