### PR TITLE
Dataloader.KV: load new items when results are non-empty

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -406,7 +406,7 @@ if Code.ensure_loaded?(Ecto) do
       defp chase_down_queryable([field | fields], schema) do
         case schema.__schema__(:association, field) do
           %{queryable: queryable} ->
-           chase_down_queryable(fields, queryable)
+            chase_down_queryable(fields, queryable)
 
           %Ecto.Association.HasThrough{through: [through_field | through_fields]} ->
             [through_field | through_fields ++ fields]

--- a/lib/dataloader/kv.ex
+++ b/lib/dataloader/kv.ex
@@ -82,8 +82,9 @@ defmodule Dataloader.KV do
 
     def fetch(source, batch_key, id) do
       with {:ok, batch} <- Map.fetch(source.results, batch_key) do
-        case Map.get(batch, id) do
+        case Map.get(batch, id, :error) do
           {:error, reason} -> {:error, reason}
+          :error -> {:error, "Unable to find id #{inspect(id)}"}
           item -> {:ok, item}
         end
       else

--- a/lib/dataloader/kv.ex
+++ b/lib/dataloader/kv.ex
@@ -82,10 +82,10 @@ defmodule Dataloader.KV do
 
     def fetch(source, batch_key, id) do
       with {:ok, batch} <- Map.fetch(source.results, batch_key) do
-        case Map.get(batch, id, :error) do
-          {:error, reason} -> {:error, reason}
+        case Map.fetch(batch, id) do
           :error -> {:error, "Unable to find id #{inspect(id)}"}
-          item -> {:ok, item}
+          {:ok, {:error, reason}} -> {:error, reason}
+          {:ok, item} -> {:ok, item}
         end
       else
         :error ->

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -73,7 +73,11 @@ defmodule Dataloader.EctoTest do
 
     rows = [
       %{user_id: user.id, title: "foo"},
-      %{user_id: user.id, title: "bar", deleted_at: DateTime.truncate(DateTime.utc_now(), :second)}
+      %{
+        user_id: user.id,
+        title: "bar",
+        deleted_at: DateTime.truncate(DateTime.utc_now(), :second)
+      }
     ]
 
     {_, [%{id: post_id} | _]} = Repo.insert_all(Post, rows, returning: [:id])
@@ -309,10 +313,10 @@ defmodule Dataloader.EctoTest do
     loaded_posts =
       loader
       |> Dataloader.get(Test, :awarded_posts, user)
+
     loaded_likes =
       loader
       |> Dataloader.get(Test, :likes, user)
-
 
     assert length(loaded_posts) == 1
     assert length(loaded_likes) == 2

--- a/test/dataloader/kv_test.exs
+++ b/test/dataloader/kv_test.exs
@@ -60,6 +60,21 @@ defmodule Dataloader.KVTest do
     assert loader != round1_loader
   end
 
+  test "loading something not in the cache does change the loader", %{loader: loader} do
+    round1_loader =
+      loader
+      |> Dataloader.load(Test, :users, "ben")
+      |> Dataloader.run()
+
+    round2_loader =
+      round1_loader
+      |> Dataloader.load(Test, :users, "bruce")
+      |> Dataloader.run()
+
+    refute round2_loader == round1_loader
+    refute loader == round1_loader
+  end
+
   test "cache can be warmed", %{loader: loader} do
     loader = Dataloader.put(loader, Test, :users, "ben", @data[:users] |> List.first())
 


### PR DESCRIPTION
Fixes issue #74.

`Map.get/2` will either return some `value()` or `nil`.

https://github.com/absinthe-graphql/dataloader/blob/56f7cb4ceb822f6d75c53188902b32a4cb9b737c/lib/dataloader/kv.ex#L85-L88

The above `case` statement does not specifically handle `nil`, because it (incorrectly) expects to find either an `:error` 2-tuple or a cached result.

However, when `fetch/3` is called by `load/3`, it is possible that:
1. `results` is a non-empty map, and
2.  there is no `results` entry matching `id`

In that case, `Map.get/2` would return `nil`, but it was being pattern-matched as a _positive result_ instead of an error, which caused the incorrect path to be followed in:
https://github.com/absinthe-graphql/dataloader/blob/56f7cb4ceb822f6d75c53188902b32a4cb9b737c/lib/dataloader/kv.ex#L72-L80

This prevented new data from being loaded into a `Dataloader.KV` source that contained cached results.

The fix proposed here is to use `Map.get/3` with a third argument of `:error`,  which can be explicitly matched in the `case` statement:

```elixir
        case Map.get(batch, id, :error) do
          {:error, reason} -> {:error, reason}
          :error -> {:error, "Unable to find id #{inspect(id)}"}
          item -> {:ok, item}
        end
```