### PR TITLE
Fix updating Dataloader.Ecto.put/4

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -357,7 +357,7 @@ if Code.ensure_loaded?(Ecto) do
             source.results,
             batch_key,
             {:ok, %{item_key => result}},
-            &Map.put(&1, item_key, result)
+            fn {:ok, map} -> {:ok, Map.put(map, item_key, result)} end
           )
 
         %{source | results: results}


### PR DESCRIPTION
https://github.com/absinthe-graphql/dataloader/commit/ce9ac3f3e4649dd15a3094ad50ba841511455d31#diff-cb130db1770f44aedd393088b4d91bcdR278

This commit changed the code to use tuples, but forgot to update the Map.update logic.
Without this change, code would fail with "expected a map, got {:ok, map}".