### PR TITLE
Update ecto.ex docs

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -26,7 +26,7 @@ if Code.ensure_loaded?(Ecto) do
     ```
 
     Querying for associations. Here we look up the `:users` association on all
-    the organizations, and the :organization for a single user.
+    the organizations, and the `:organization` for a single user.
 
     ```elixir
     loader =


### PR DESCRIPTION
use backticks for atom in documentation (as the rest is using it)