### PR TITLE
Refactor/remove unecessary inspect calls

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -369,7 +369,7 @@ if Code.ensure_loaded?(Ecto) do
           |> normalize_key(source.default_params)
           |> get_keys(item)
 
-        unless fetched?(source, batch_key, item_key) do
+        unless fetched?(source.results, batch_key, item_key) do
           entry = {item_key, item}
 
           update_in(source.batches, fn batches ->
@@ -380,13 +380,11 @@ if Code.ensure_loaded?(Ecto) do
         end
       end
 
-      defp fetched?(%{results: results}, batch_key, item_key) do
-        with {:ok, batch} <- Map.fetch(results, batch_key),
-             {:ok, _result} <- fetch_item_from_batch(batch, item_key) do
-          true
-        else
-          _ ->
-            false
+      defp fetched?(results, batch_key, item_key) do
+        case Map.fetch(results, batch_key)  do
+          :error -> false
+          {:ok, {:error, _reason}} -> false
+          {:ok, {:ok, batch}} -> Map.has_key?(batch, item_key)
         end
       end
 

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -381,10 +381,9 @@ if Code.ensure_loaded?(Ecto) do
       end
 
       defp fetched?(results, batch_key, item_key) do
-        case Map.fetch(results, batch_key) do
-          :error -> false
-          {:ok, {:error, _reason}} -> false
-          {:ok, {:ok, batch}} -> Map.has_key?(batch, item_key)
+        case results do
+          %{^batch_key => {:ok, %{^item_key => _}}} -> true
+          _ -> false
         end
       end
 

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -369,19 +369,19 @@ if Code.ensure_loaded?(Ecto) do
           |> normalize_key(source.default_params)
           |> get_keys(item)
 
-        unless fetched?(source.results, batch_key, item_key) do
+        if fetched?(source.results, batch_key, item_key) do
+          source
+        else
           entry = {item_key, item}
 
           update_in(source.batches, fn batches ->
             Map.update(batches, batch_key, MapSet.new([entry]), &MapSet.put(&1, entry))
           end)
-        else
-          source
         end
       end
 
       defp fetched?(results, batch_key, item_key) do
-        case Map.fetch(results, batch_key)  do
+        case Map.fetch(results, batch_key) do
           :error -> false
           {:ok, {:error, _reason}} -> false
           {:ok, {:ok, batch}} -> Map.has_key?(batch, item_key)

--- a/lib/dataloader/kv.ex
+++ b/lib/dataloader/kv.ex
@@ -79,15 +79,10 @@ defmodule Dataloader.KV do
     end
 
     defp fetched?(results, batch_key, id) do
-      with {:ok, batch} <- Map.fetch(results, batch_key) do
-        case Map.fetch(batch, id) do
-          :error -> false
-          {:ok, {:error, _reason}} -> false
-          {:ok, _item} -> true
-        end
-      else
-        :error ->
-          false
+      case results do
+        %{^batch_key => %{^id => {:error, _}}}  -> false
+        %{^batch_key => %{^id => _}}  -> true
+        _ -> false
       end
     end
 

--- a/lib/dataloader/kv.ex
+++ b/lib/dataloader/kv.ex
@@ -69,12 +69,12 @@ defmodule Dataloader.KV do
     end
 
     def load(source, batch_key, id) do
-      unless fetched?(source.results, batch_key, id) do
-          update_in(source.batches, fn batches ->
-            Map.update(batches, batch_key, MapSet.new([id]), &MapSet.put(&1, id))
-          end)
-      else
+      if fetched?(source.results, batch_key, id) do
         source
+      else
+        update_in(source.batches, fn batches ->
+          Map.update(batches, batch_key, MapSet.new([id]), &MapSet.put(&1, id))
+        end)
       end
     end
 


### PR DESCRIPTION
### Remove unnecessary inspect calls. 

absinthe-graphql/absinthe#573 issue has shown a big percentual time to resolve queries after they're fetched from the database. 

After some debug @jeroenvisser101 [pointed one of the problems](https://github.com/absinthe-graphql/absinthe/issues/573#issuecomment-550214687).

> ... I did some further investigation, and found that the inspect calls are actually made from dataloader: absinthe-graphql/dataloader@ce9ac3f#diff-cb130db1770f44aedd393088b4d91bcdR252 ...

> It seems like some changes were made in the way errors are reported. Dataloader.Ecto seems to rely on errors to update pending batches, because it abuses fetch/3 to check if a value has previously been loaded. If we either added a argument to fetch/3 to toggle detailed errors, or to introduce fetched?/3 and used that in load/3, we would prevent inspect calls.

I got the call and refactored load creating a `fetched?/3` function, so it will not pass through unnecessary `inspect` calls on both `kv` and `ecto` implementations. 

[Debugging the problem](https://github.com/pmargreff/absinthe_test/blob/master/test/absinthe_test_web/absinthe/books_test.exs#L41) summed inspect calls represents 13% of the time (sample above). 
```
'Elixir.Inspect.Atom':inspect/2                                                                   40000     0.18     5363  [      0.13]
'Elixir.Inspect.Algebra':'-container_doc/6-fun-0-'/4                                              50000     0.19     5622  [      0.11]
'Elixir.Inspect.Algebra':nest/2                                                                   10000     0.08     2290  [      0.23]
'Elixir.Inspect.Tuple':inspect/2                                                                  10000     0.05     1577  [      0.16]
'Elixir.Inspect.Map':inspect/3                                                                    10000     0.06     1715  [      0.17]
'Elixir.Inspect.PID':inspect/2                                                                    10000     0.06     1804  [      0.18]
'Elixir.Inspect.Algebra':container_each/6                                                         70000     0.42    12405  [      0.18]
'Elixir.Inspect.Algebra':flex_break/1                                                             50000     0.49    14245  [      0.28]
'Elixir.Inspect.Opts':'__struct__'/0                                                              10001     0.09     2494  [      0.25]
'Elixir.Inspect.Algebra':apply_nesting/3                                                          10000     0.09     2495  [      0.25]
'Elixir.Inspect.Algebra':group/2                                                                  20001     0.09     2775  [      0.14]
'Elixir.Inspect.Algebra':flex_glue/2                                                              50000     0.19     5665  [      0.11]
'Elixir.Inspect.Algebra':join/4                                                                   50000     0.22     6501  [      0.13]
'Elixir.Inspect.Algebra':flex_glue/3                                                              50000     0.22     6523  [      0.13]
'Elixir.Inspect.Atom':color_key/1                                                                 40000     0.32     9400  [      0.23]
'Elixir.Inspect':impl_for/1                                                                       70001     0.32     9406  [      0.13]
'Elixir.Inspect':'impl_for!'/1                                                                    70001     0.67    19677  [      0.28]
'Elixir.Inspect.Algebra':to_doc/2                                                                 70001     0.70    20405  [      0.29]
'Elixir.Inspect.Algebra':color/3                                                                 100001     0.81    23779  [      0.24]
'Elixir.Inspect.Algebra':decrement/1                                                              60000     1.08    31509  [      0.53]
'Elixir.Inspect.Algebra':concat/2                                                                180000     1.25    36417  [      0.20]
'Elixir.Inspect.Algebra':fold_doc/2                                                               60000     1.39    40727  [      0.68]
'Elixir.Inspect.Algebra':format/3                                                                410003     2.97    86865  [      0.21]
```

After the refactor the same query using Dataloader now goes from something like `11_502_307` to `8_260_419` fn calls. [Complete results here](https://gist.github.com/pmargreff/909fb4c5e4d0911a697147efc6b92549). 
