### PR TITLE
Avoid preloads in lateral subqueries

### DIFF
--- a/test/dataloader/ecto/limit_query_test.exs
+++ b/test/dataloader/ecto/limit_query_test.exs
@@ -33,6 +33,7 @@ defmodule Dataloader.LimitQueryTest do
     |> having(count() >= ^n)
     |> order_by(^order_by)
     |> limit(^limit)
+    |> preload([likes: :user])
   end
 
   defp query(schema, %{limit: limit, order_by: order_by}, test_pid) do
@@ -212,7 +213,9 @@ defmodule Dataloader.LimitQueryTest do
       |> Dataloader.load_many(Test, args, [user1, user2])
       |> Dataloader.run()
 
-    assert [post2] = Dataloader.get(loader, Test, args, user1)
-    assert [post3] = Dataloader.get(loader, Test, args, user2)
+    assert [p1 = %{title: "bar"}] = Dataloader.get(loader, Test, args, user1)
+    assert [p2 = %{title: "baz"}] = Dataloader.get(loader, Test, args, user2)
+    assert [%{user: %{username: "Bruce Williams"}}] = p1.likes
+    assert [%{user: %{username: "Ben Wilson"}}] = p2.likes
   end
 end


### PR DESCRIPTION
Relates to #97 

Ecto doesn't allow preloads in subqueries, so this PR moves any preloads out to a call to `Repo.preload`.
This should support basic keyword preloads, but join preloads are dropped.

It also avoids using a lateral join when loading rows by primary key with a limit, as in the example in #97.