### PR TITLE
feat: Support overriding Task module

### DIFF
--- a/lib/dataloader.ex
+++ b/lib/dataloader.ex
@@ -268,6 +268,6 @@ defmodule Dataloader do
   @doc deprecated: "Use async_safely/3 instead"
   @spec pmap(list(), fun(), keyword()) :: map()
   def pmap(items, fun, opts \\ []) do
-    Dataloader.Async.tasks(Dataloader, items, fun, opts)
+    Dataloader.Async.tasks(%Dataloader{}, items, fun, opts)
   end
 end

--- a/lib/dataloader.ex
+++ b/lib/dataloader.ex
@@ -156,7 +156,7 @@ defmodule Dataloader do
         Dataloader.Async.tasks(
           dataloader,
           dataloader.sources,
-          fn {name, source} -> {name, Source.run(source)} end,
+          fn {name, source} -> {name, Source.run(source, dataloader)} end,
           timeout: timeout(dataloader)
         )
         |> Enum.map(fn

--- a/lib/dataloader/async.ex
+++ b/lib/dataloader/async.ex
@@ -1,17 +1,8 @@
 defprotocol Dataloader.Task do
-  @fallback_to_any true
-
   def await(x, task, timeout)
   def async(x, f)
   def async_stream(x, xs, f, opts)
   def timeout(x)
-end
-
-defimpl Dataloader.Task, for: Any do
-  def await(_, task, timeout), do: Task.await(task, timeout)
-  def async(_, f), do: Task.async(f)
-  def async_stream(_, xs, f, opts), do: Task.async_stream(xs, f, opts)
-  def timeout(_), do: Dataloader.default_timeout()
 end
 
 defimpl Dataloader.Task, for: Dataloader do

--- a/lib/dataloader/async.ex
+++ b/lib/dataloader/async.ex
@@ -1,0 +1,64 @@
+defprotocol Dataloader.Task do
+  @fallback_to_any true
+
+  def await(x, task, timeout)
+  def async(x, f)
+  def async_stream(x, xs, f, opts)
+  def timeout(x)
+end
+
+defimpl Dataloader.Task, for: Any do
+  def await(_, task, timeout), do: Task.await(task, timeout)
+  def async(_, f), do: Task.async(f)
+  def async_stream(_, xs, f, opts), do: Task.async_stream(xs, f, opts)
+  def timeout(_), do: Dataloader.default_timeout()
+end
+
+defimpl Dataloader.Task, for: Dataloader do
+  def await(d, task, timeout), do: d.task.await(task, timeout)
+  def async(d, f), do: d.task.async(f)
+  def async_stream(d, xs, f, opts), do: d.task.async_stream(xs, f, opts)
+  def timeout(d), do: Dataloader.timeout(d)
+end
+
+defmodule Dataloader.Async do
+  @doc """
+  This is a helper method to run a set of async tasks in such a way that if
+  one of the tasks crashing will not crash the caller spawning them. Instead,
+  crashes will be rewritten to {:error, reason}.
+
+  This leverages the fact that Task.async_stream/3 will return {:exit, reason}
+  for any tasks that crash during execution as long as the calling process
+  it trappings exits. In order to avoid changing Process flags on the caller,
+  we spawn an intermediary task which we set to trap exits, and then call
+  Task.async_stream/3 from the spawned task.
+
+  See `run_task/3` for an example of a `fun` implementation, this will return
+  whatever that returns.
+  """
+  @spec tasks(module(), atom(), list()) :: any()
+  def tasks(async, xs, fun, opts \\ []) do
+    task_opts =
+      opts
+      |> Keyword.take([:timeout, :max_concurrency])
+      |> Keyword.put_new(:timeout, Dataloader.Task.timeout(async))
+      |> Keyword.put(:on_timeout, :kill_task)
+
+    task =
+      Dataloader.Task.async(async, fn ->
+        # The purpose of `:trap_exit` here is so that we can ensure that any failures
+        # within the tasks do not kill the current process. We want to get results
+        # back no matter what.
+        Process.flag(:trap_exit, true)
+
+        Dataloader.Task.async_stream(async, xs, fun, task_opts)
+        |> Enum.map(fn
+          {:ok, result} -> {:ok, result}
+          {:exit, reason} -> {:error, reason}
+        end)
+      end)
+
+    res = Dataloader.Task.await(async, task, :infinity)
+    Enum.zip(xs, res) |> Map.new()
+  end
+end

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -381,16 +381,15 @@ if Code.ensure_loaded?(Ecto) do
     end
 
     defimpl Dataloader.Source do
-      def run(source) do
+      def run(source, dataloader) do
         options = [
           timeout: source.options[:timeout] || Dataloader.default_timeout(),
           on_timeout: :kill_task
         ]
 
-        # TODO: Need to pass in a reference to async here.
         results =
           Dataloader.Async.tasks(
-            Dataloader,
+            dataloader,
             source.batches,
             fn batch ->
               id = :erlang.unique_integer()

--- a/lib/dataloader/kv.ex
+++ b/lib/dataloader/kv.ex
@@ -131,8 +131,8 @@ defmodule Dataloader.KV do
         {batch_key, source.load_function.(batch_key, ids)}
       end
 
-      results =
-        Dataloader.async_safely(Dataloader, :run_tasks, [source.batches, fun, source.opts])
+      # TODO: Need to pass in a reference to async here.
+      results = Dataloader.Async.tasks(Dataloader, source.batches, fun, source.opts)
 
       %{source | batches: %{}, results: merge_results(source.results, results)}
     end

--- a/lib/dataloader/kv.ex
+++ b/lib/dataloader/kv.ex
@@ -126,13 +126,12 @@ defmodule Dataloader.KV do
       end
     end
 
-    def run(source) do
+    def run(source, dataloader) do
       fun = fn {batch_key, ids} ->
         {batch_key, source.load_function.(batch_key, ids)}
       end
 
-      # TODO: Need to pass in a reference to async here.
-      results = Dataloader.Async.tasks(Dataloader, source.batches, fun, source.opts)
+      results = Dataloader.Async.tasks(dataloader, source.batches, fun, source.opts)
 
       %{source | batches: %{}, results: merge_results(source.results, results)}
     end

--- a/lib/dataloader/source.ex
+++ b/lib/dataloader/source.ex
@@ -11,8 +11,8 @@ defprotocol Dataloader.Source do
   @doc """
   Run any batches queued up for this source.
   """
-  @spec run(t) :: t
-  def run(source)
+  @spec run(t, Dataloader.Task.t()) :: t
+  def run(source, dataloader)
 
   @doc """
   Fetch the result found under the given batch and item keys.


### PR DESCRIPTION
Hi!

This PR implements the possibility to override what `Task` module is used by Dataloader. This would allow users to provide a customized Task module that can e.g properly propagate tracing contexts to spawned tasks using the process dictionary.

This is still a WIP but I wanted to get some discussion around the approach going.

What I've done is two things: I've extracted `Dataloader.async_safely` together with `Dataloader.run_tasks` into a single function, `Dataloader.Async.tasks/4`. This function accepts a additional arguments, a reference to something which implements the `Dataloader.Task` protocol the notion of a `Task` module, which `Dataloader` itself implements. So far so good.

The final piece of the puzzle would be for `Dataloader` to pass in itself to each `source` it adds as the source's `Task` module. This way in order for each registered loader would have the reference to a `Dataloader.Task` as the top level `Dataloader` would.

While I think this makes sense from the point of view of an end user, I fear that this API will feel kind of clunky, but it's also an API that will be inherently hard to contractually guarantee, since each implementor of `Dataloader.Source` will need to not only somehow accept a `Task`, but also make sure it's properly used whenever it needs to run tasks. And it's definitely a breaking API change.

I think the crux of the issue is that it, from a user point of view, would make sense for `Dataloader` as well as any loaders registered to it to use the same `Task`, but both `Dataloader.run/1` as well as internals of each source needing to run async operations.

Would be happy to get some discussions going around this!