### PR TITLE
Use the same database prefix as the existing rows when preloading via a lateral join

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -673,8 +673,11 @@ if Code.ensure_loaded?(Ecto) do
 
       def preload_lateral([], _assoc, _query, _opts), do: []
 
-      def preload_lateral([%schema{} | _] = structs, assoc, query, repo, repo_opts) do
+      def preload_lateral([%schema{} = struct | _] = structs, assoc, query, repo, repo_opts) do
         [pk] = schema.__schema__(:primary_key)
+
+        # Carry the database prefix across from already-loaded records if not already set
+        repo_opts = Keyword.put_new(repo_opts, :prefix, struct.__meta__.prefix)
 
         assocs = expand_assocs(schema, [assoc])
 


### PR DESCRIPTION
This fixes the specific issue I was having in #105 (preloads not using the same database prefix as the records being preloaded from), but I don't think it will be a complete solution - there are a few other calls to `repo.all` in the file that will probably have the same problem. 

I'm not sure what the best approach to fixing them all in an idiomatic way would be.