### PR TITLE
Fix function call in Ecto basic usage example

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -22,7 +22,7 @@ if Code.ensure_loaded?(Ecto) do
       |> Dataloader.load_many(Accounts, Organization, [4, 9])
       |> Dataloader.run
 
-    organizations = Dataloader.get(loader, Accounts, Organization, [4,9])
+    organizations = Dataloader.get_many(loader, Accounts, Organization, [4,9])
     ```
 
     Querying for associations. Here we look up the `:users` association on all


### PR DESCRIPTION
The Ecto "Basic Usage" example calls `Dataloader.get/4` which is only useful for getting single records, but  `Dataloader.get_many/4` is the correct function for fetching multiple records. This PR updates the example accordingly.