### PR TITLE
Misc doc changes

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,3 +1,4 @@
+# Used by "mix format"
 [
-  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 # The directory Mix downloads your dependencies sources to.
 /deps/
 
-# Where 3rd-party dependencies like ExDoc output generated docs.
+# Where third-party dependencies like ExDoc output generated docs.
 /doc/
 
 # Ignore .fetch files in case you like to edit your project deps locally.
@@ -18,4 +18,9 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
-.elixir_ls
+
+# Ignore package tarball (built via "mix hex.build").
+dataloader-*.tar
+
+# Temporary files for e.g. tests.
+/tmp/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 # Dataloader
 
+[![Build Status](https://img.shields.io/travis/absinthe-graphql/dataloader.svg?style=flat-square)](https://travis-ci.org/absinthe-graphql/dataloader)
+[![Version](https://img.shields.io/hexpm/v/dataloader.svg)](https://hex.pm/packages/dataloader)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/dataloader/)
+[![Download](https://img.shields.io/hexpm/dt/dataloader.svg)](https://hex.pm/packages/dataloader)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Last Updated](https://img.shields.io/github/last-commit/absinthe-graphql/dataloader.svg)](https://github.com/absinthe-graphql/dataloader/commits/master)
+
 Dataloader provides an easy way efficiently load data in batches. It's inspired
 by https://github.com/facebook/dataloader, although it makes some small API
 changes to better suit Elixir use cases.
 
 ## Installation
 
-The package can be installed by adding [`dataloader`](https://hex.pm/packages/dataloader) to your list of dependencies in `mix.exs`:
+The package can be installed by adding [`:dataloader`](https://hex.pm/packages/dataloader) to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -21,7 +28,7 @@ end
 Central to Dataloader is the idea of a source. A single Dataloader struct can
 have many different sources, which represent different ways to load data.
 
-Here's an example of a data loader using an ecto source, and then loading some
+Here's an example of a data loader using an Ecto source, and then loading some
 organization data.
 
 ```elixir

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,7 @@
 defmodule Dataloader.Mixfile do
   use Mix.Project
 
+  @source_url "https://github.com/absinthe-graphql/dataloader"
   @version "1.0.8"
 
   def project do
@@ -12,16 +13,8 @@ defmodule Dataloader.Mixfile do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       aliases: aliases(),
-      source_url: "https://github.com/absinthe-graphql/dataloader",
-      docs: [
-        main: "Dataloader",
-        source_ref: "v#{@version}",
-        extras: [
-          "CHANGELOG.md",
-          "guides/telemetry.md"
-        ]
-      ],
-      deps: deps()
+      deps: deps(),
+      docs: docs()
     ]
   end
 
@@ -32,8 +25,8 @@ defmodule Dataloader.Mixfile do
       maintainers: ["Ben Wilson"],
       licenses: ["MIT"],
       links: %{
-        Changelog: "https://github.com/absinthe-graphql/dataloader/blob/master/CHANGELOG.md",
-        GitHub: "https://github.com/absinthe-graphql/dataloader"
+        Changelog: "https://hexdocs/dataloader/changelog.html",
+        GitHub: @source_url
       }
     ]
   end
@@ -41,7 +34,6 @@ defmodule Dataloader.Mixfile do
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger] ++ test_apps(Mix.env())
@@ -59,17 +51,27 @@ defmodule Dataloader.Mixfile do
 
   defp test_apps(_), do: []
 
-  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ecto, ">= 3.4.3 and < 4.0.0", optional: true},
       {:telemetry, "~> 0.4"},
+      {:ecto, ">= 3.4.3 and < 4.0.0", optional: true},
       {:ecto_sql, "~> 3.0", optional: true, only: :test},
-      {:postgrex, "~> 0.14", only: :test},
-      {:dialyxir, "~> 0.5", only: :dev},
-      {:ex_doc, ">= 0.0.0", only: [:dev]}
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      {:postgrex, "~> 0.14", only: :test, runtime: false},
+      {:dialyxir, "~> 0.5", only: :dev, runtime: false},
+      {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
+    ]
+  end
+
+  def docs do
+    [
+      extras: [
+        "CHANGELOG.md",
+        "README.md",
+        "guides/telemetry.md"
+      ],
+      main: "readme",
+      source_url: @source_url,
+      source_ref: "v#{@version}"
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Dataloader.Mixfile do
       maintainers: ["Ben Wilson"],
       licenses: ["MIT"],
       links: %{
-        Changelog: "https://hexdocs/dataloader/changelog.html",
+        Changelog: "https://hexdocs.pm/dataloader/changelog.html",
         GitHub: @source_url
       }
     ]


### PR DESCRIPTION
Besides other changes, this commit ensures the generated HTML doc for
HexDocs.pm will become the main source doc for this Elixir library which
leverage on ExDoc features.

List of changes:
* Update gitignore
* Update formatter config
* Use common source url
* Set readme as main doc
* Badges and more badges!

Screenshot:
![Screenshot-20210305232914-2692x1462](https://user-images.githubusercontent.com/134518/110137246-95ecdb80-7e0b-11eb-8049-aeef0e10ae1c.png)
