### PR TITLE
Add support for where and join_where in many_to_many and has_many associations

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -773,7 +773,6 @@ if Code.ensure_loaded?(Ecto) do
            ) do
         [{owner_join_key, owner_key}, {related_join_key, related_key}] = assoc.join_keys
 
-
         join_query =
           query
           |> join(:inner, [..., x], y in ^assoc.join_through,

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -759,16 +759,14 @@ if Code.ensure_loaded?(Ecto) do
           )
           |> where([..., x], field(x, ^owner_join_key) == field(parent_as(:parent), ^owner_key))
 
-        case assoc.join_where do
-          [{where_field, where_value}] ->
-            join
-            |> where([..., x], field(x, ^where_field) == ^where_value)
+        binds = Ecto.Query.Builder.count_binds(join)
 
-          _otherwise ->
-            join
-        end
+        join
+        |> Ecto.Association.combine_joins_query(assoc.where, 0)
+        |> Ecto.Association.combine_joins_query(assoc.join_where, binds - 1)
       end
 
+      # Fix me: never called because the functions that call this are never called
       defp build_preload_lateral_query(
              [%Ecto.Association.ManyToMany{} = assoc],
              query,
@@ -796,6 +794,7 @@ if Code.ensure_loaded?(Ecto) do
         )
       end
 
+      # Fix me: never called because assoc is always length == 1
       defp build_preload_lateral_query(
              [%Ecto.Association.ManyToMany{} = assoc | rest],
              query,
@@ -815,6 +814,7 @@ if Code.ensure_loaded?(Ecto) do
         build_preload_lateral_query(rest, query, :join_last)
       end
 
+      # Fix me: never called because assoc is always length == 1
       defp build_preload_lateral_query(
              [%Ecto.Association.ManyToMany{} = assoc | rest],
              query,

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -826,7 +826,6 @@ if Code.ensure_loaded?(Ecto) do
         build_preload_lateral_query(rest, query, :join_last)
       end
 
-      # Fix me: never called because assoc is always length == 1
       defp build_preload_lateral_query(
              [%Ecto.Association.ManyToMany{} = assoc | rest],
              query,
@@ -834,7 +833,7 @@ if Code.ensure_loaded?(Ecto) do
            ) do
         [{owner_join_key, owner_key}, {related_join_key, related_key}] = assoc.join_keys
 
-        query =
+        join_query =
           query
           |> join(:inner, [..., x], y in ^assoc.join_through,
             on: field(x, ^related_key) == field(y, ^related_join_key)
@@ -842,6 +841,13 @@ if Code.ensure_loaded?(Ecto) do
           |> join(:inner, [..., x], y in ^assoc.owner,
             on: field(x, ^owner_join_key) == field(y, ^owner_key)
           )
+
+        binds_count = Ecto.Query.Builder.count_binds(join_query)
+
+        query =
+          join_query
+          |> Ecto.Association.combine_joins_query(assoc.where, binds_count - 3)
+          |> Ecto.Association.combine_joins_query(assoc.join_where, binds_count - 2)
 
         build_preload_lateral_query(rest, query, :join_last)
       end

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -787,10 +787,17 @@ if Code.ensure_loaded?(Ecto) do
         |> Ecto.Association.combine_joins_query(assoc.join_where, binds_count - 1)
       end
 
+      defp build_preload_lateral_query([%Ecto.Association.Has{} = assoc], query, :join_first) do
+        query
+        |> where([x], field(x, ^assoc.related_key) == field(parent_as(:parent), ^assoc.owner_key))
+        |> Ecto.Association.combine_assoc_query(assoc.where)
+      end
+
       defp build_preload_lateral_query([assoc], query, :join_first) do
         query
         |> where([x], field(x, ^assoc.related_key) == field(parent_as(:parent), ^assoc.owner_key))
       end
+
 
       defp build_preload_lateral_query([assoc], query, :join_last) do
         query

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -752,11 +752,21 @@ if Code.ensure_loaded?(Ecto) do
            ) do
         [{owner_join_key, owner_key}, {related_join_key, related_key}] = assoc.join_keys
 
-        query
-        |> join(:inner, [x], y in ^assoc.join_through,
-          on: field(x, ^related_key) == field(y, ^related_join_key)
-        )
-        |> where([..., x], field(x, ^owner_join_key) == field(parent_as(:parent), ^owner_key))
+        join =
+          query
+          |> join(:inner, [x], y in ^assoc.join_through,
+            on: field(x, ^related_key) == field(y, ^related_join_key)
+          )
+          |> where([..., x], field(x, ^owner_join_key) == field(parent_as(:parent), ^owner_key))
+
+        case assoc.join_where do
+          [{where_field, where_value}] ->
+            join
+            |> where([..., x], field(x, ^where_field) == ^where_value)
+
+          _otherwise ->
+            join
+        end
       end
 
       defp build_preload_lateral_query(

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -798,6 +798,19 @@ if Code.ensure_loaded?(Ecto) do
         |> where([x], field(x, ^assoc.related_key) == field(parent_as(:parent), ^assoc.owner_key))
       end
 
+      defp build_preload_lateral_query([%Ecto.Association.Has{} = assoc], query, :join_last) do
+        join_query =
+          query
+          |> where(
+            [..., x],
+            field(x, ^assoc.related_key) == field(parent_as(:parent), ^assoc.owner_key)
+          )
+
+        binds_count = Ecto.Query.Builder.count_binds(join_query)
+
+        join_query
+        |> Ecto.Association.combine_joins_query(assoc.where, binds_count - 1)
+      end
 
       defp build_preload_lateral_query([assoc], query, :join_last) do
         query

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -785,6 +785,7 @@ if Code.ensure_loaded?(Ecto) do
 
         join_query
         |> Ecto.Association.combine_joins_query(assoc.where, binds_count - 2)
+        |> Ecto.Association.combine_joins_query(assoc.join_where, binds_count - 1)
       end
 
       defp build_preload_lateral_query([assoc], query, :join_first) do

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -762,7 +762,7 @@ if Code.ensure_loaded?(Ecto) do
         binds_count = Ecto.Query.Builder.count_binds(join_query)
 
         join_query
-        |> Ecto.Association.combine_joins_query(assoc.where, 0)
+        |> Ecto.Association.combine_joins_query(assoc.where, binds_count - 2)
         |> Ecto.Association.combine_joins_query(assoc.join_where, binds_count - 1)
       end
 

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -787,18 +787,13 @@ if Code.ensure_loaded?(Ecto) do
         |> Ecto.Association.combine_joins_query(assoc.join_where, binds_count - 1)
       end
 
-      defp build_preload_lateral_query([%Ecto.Association.Has{} = assoc], query, :join_first) do
+      defp build_preload_lateral_query([assoc], query, :join_first) do
         query
         |> where([x], field(x, ^assoc.related_key) == field(parent_as(:parent), ^assoc.owner_key))
         |> Ecto.Association.combine_assoc_query(assoc.where)
       end
 
-      defp build_preload_lateral_query([assoc], query, :join_first) do
-        query
-        |> where([x], field(x, ^assoc.related_key) == field(parent_as(:parent), ^assoc.owner_key))
-      end
-
-      defp build_preload_lateral_query([%Ecto.Association.Has{} = assoc], query, :join_last) do
+      defp build_preload_lateral_query([assoc], query, :join_last) do
         join_query =
           query
           |> where(
@@ -810,14 +805,6 @@ if Code.ensure_loaded?(Ecto) do
 
         join_query
         |> Ecto.Association.combine_joins_query(assoc.where, binds_count - 1)
-      end
-
-      defp build_preload_lateral_query([assoc], query, :join_last) do
-        query
-        |> where(
-          [..., x],
-          field(x, ^assoc.related_key) == field(parent_as(:parent), ^assoc.owner_key)
-        )
       end
 
       defp build_preload_lateral_query(
@@ -873,7 +860,7 @@ if Code.ensure_loaded?(Ecto) do
       end
 
       defp build_preload_lateral_query(
-             [%Ecto.Association.Has{} = assoc | rest],
+             [assoc | rest],
              query,
              :join_first
            ) do
@@ -887,18 +874,8 @@ if Code.ensure_loaded?(Ecto) do
         build_preload_lateral_query(rest, query, :join_last)
       end
 
-      defp build_preload_lateral_query([assoc | rest], query, :join_first) do
-        query =
-          query
-          |> join(:inner, [x], y in ^assoc.owner,
-            on: field(x, ^assoc.related_key) == field(y, ^assoc.owner_key)
-          )
-
-        build_preload_lateral_query(rest, query, :join_last)
-      end
-
       defp build_preload_lateral_query(
-             [%Ecto.Association.Has{} = assoc | rest],
+             [assoc | rest],
              query,
              :join_last
            ) do
@@ -912,16 +889,6 @@ if Code.ensure_loaded?(Ecto) do
           )
 
         build_preload_lateral_query(rest, join_query, :join_last)
-      end
-
-      defp build_preload_lateral_query([assoc | rest], query, :join_last) do
-        query =
-          query
-          |> join(:inner, [..., x], y in ^assoc.owner,
-            on: field(x, ^assoc.related_key) == field(y, ^assoc.owner_key)
-          )
-
-        build_preload_lateral_query(rest, query, :join_last)
       end
 
       defp maybe_distinct(query, [%Ecto.Association.Has{}, %Ecto.Association.BelongsTo{} | _]) do

--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -762,7 +762,7 @@ if Code.ensure_loaded?(Ecto) do
         binds_count = Ecto.Query.Builder.count_binds(join_query)
 
         join_query
-        |> Ecto.Association.combine_joins_query(assoc.where, binds_count - 2)
+        |> Ecto.Association.combine_joins_query(assoc.where, 0)
         |> Ecto.Association.combine_joins_query(assoc.join_where, binds_count - 1)
       end
 
@@ -840,7 +840,7 @@ if Code.ensure_loaded?(Ecto) do
 
         query =
           join_query
-          |> Ecto.Association.combine_joins_query(assoc.where, binds_count - 3)
+          |> Ecto.Association.combine_joins_query(assoc.where, 0)
           |> Ecto.Association.combine_joins_query(assoc.join_where, binds_count - 2)
 
         build_preload_lateral_query(rest, query, :join_last)

--- a/priv/test_repo/migrations/1_migrate_all.exs
+++ b/priv/test_repo/migrations/1_migrate_all.exs
@@ -26,5 +26,15 @@ defmodule Absinthe.Ecto.TestRepo.Migrations.MigrateAll do
       add :leaderboard_id, references(:leaderboards), null: false
       add :post_id, references(:posts), null: false
     end
+
+    create table(:pictures) do
+      add :url, :string, null: false
+    end
+
+    create table(:user_pictures) do
+      add :status, :string, default: "unpublished"
+      add :user_id, references(:users), null: false
+      add :picture_id, references(:pictures), null: false
+    end
   end
 end

--- a/priv/test_repo/migrations/1_migrate_all.exs
+++ b/priv/test_repo/migrations/1_migrate_all.exs
@@ -21,6 +21,7 @@ defmodule Absinthe.Ecto.TestRepo.Migrations.MigrateAll do
     create table(:likes) do
       add :user_id, references(:users), null: false
       add :post_id, references(:posts), null: false
+      add :status, :string
     end
 
     create table(:scores) do

--- a/priv/test_repo/migrations/1_migrate_all.exs
+++ b/priv/test_repo/migrations/1_migrate_all.exs
@@ -14,6 +14,7 @@ defmodule Absinthe.Ecto.TestRepo.Migrations.MigrateAll do
     create table(:posts) do
       add :user_id, references(:users)
       add :title, :string
+      add :status, :string
       add :deleted_at, :utc_datetime
     end
 

--- a/priv/test_repo/migrations/1_migrate_all.exs
+++ b/priv/test_repo/migrations/1_migrate_all.exs
@@ -28,11 +28,12 @@ defmodule Absinthe.Ecto.TestRepo.Migrations.MigrateAll do
     end
 
     create table(:pictures) do
+      add :status, :string
       add :url, :string, null: false
     end
 
     create table(:user_pictures) do
-      add :status, :string, default: "unpublished"
+      add :status, :string
       add :user_id, references(:users), null: false
       add :picture_id, references(:pictures), null: false
     end

--- a/priv/test_repo/migrations/1_migrate_all.exs
+++ b/priv/test_repo/migrations/1_migrate_all.exs
@@ -18,12 +18,6 @@ defmodule Absinthe.Ecto.TestRepo.Migrations.MigrateAll do
       add :deleted_at, :utc_datetime
     end
 
-    create table(:likes) do
-      add :user_id, references(:users), null: false
-      add :post_id, references(:posts), null: false
-      add :status, :string
-    end
-
     create table(:scores) do
       add :leaderboard_id, references(:leaderboards), null: false
       add :post_id, references(:posts), null: false
@@ -38,6 +32,13 @@ defmodule Absinthe.Ecto.TestRepo.Migrations.MigrateAll do
       add :status, :string
       add :user_id, references(:users), null: false
       add :picture_id, references(:pictures), null: false
+    end
+
+    create table(:likes) do
+      add :user_id, references(:users), null: false
+      add :post_id, references(:posts)
+      add :picture_id, references(:pictures)
+      add :status, :string
     end
   end
 end

--- a/test/dataloader/ecto/belongs_to_test.exs
+++ b/test/dataloader/ecto/belongs_to_test.exs
@@ -1,0 +1,68 @@
+defmodule Dataloader.Ecto.BelongsToTest do
+  use ExUnit.Case, async: true
+
+  alias Dataloader.{User, Post, Like}
+  import Ecto.Query
+  alias Dataloader.TestRepo, as: Repo
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+    test_pid = self()
+
+    source =
+      Dataloader.Ecto.new(
+        Repo,
+        query: &query(&1, &2, test_pid)
+      )
+
+    loader =
+      Dataloader.new()
+      |> Dataloader.add_source(Test, source)
+
+    {:ok, loader: loader}
+  end
+
+  defp query(schema, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    schema
+    |> limit(^limit)
+  end
+
+  describe "where in belongs_to association" do
+    test "returns entity when where clause matches", %{loader: loader} do
+      user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+
+      post1 = %Post{user_id: user1.id, title: "foo", status: "published"} |> Repo.insert!()
+
+      like1 = %Like{user_id: user1.id, post_id: post1.id} |> Repo.insert!()
+
+      args = {:post, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, like1)
+        |> Dataloader.run()
+
+      assert post1 == Dataloader.get(loader, Test, args, like1)
+    end
+
+    test "returns nil when where clause doesn't match", %{loader: loader} do
+      user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+
+      post1 = %Post{user_id: user1.id, title: "foo", status: "unpublished"} |> Repo.insert!()
+
+      like1 = %Like{user_id: user1.id, post_id: post1.id} |> Repo.insert!()
+
+      args = {:post, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, like1)
+        |> Dataloader.run()
+
+      assert nil == Dataloader.get(loader, Test, args, like1)
+    end
+  end
+end

--- a/test/dataloader/ecto/has_many_through_many_to_many_test.exs
+++ b/test/dataloader/ecto/has_many_through_many_to_many_test.exs
@@ -39,6 +39,30 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
     |> join(:left, [u], p in assoc(u, :posts))
   end
 
+  defp query(Like, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    Like
+    |> limit(^limit)
+    |> join(:left, [l], u in User, on: l.user_id == u.id)
+  end
+
+  defp query(Score, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    Score
+    |> limit(^limit)
+    |> join(:left, [s], p in Post, on: s.post_id == p.id)
+  end
+
+  defp query(Picture, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    Picture
+    |> limit(^limit)
+    |> join(:left, [p], l in assoc(p, :likes))
+  end
+
   defp query(schema, %{limit: limit}, test_pid) do
     send(test_pid, :querying)
 

--- a/test/dataloader/ecto/has_many_through_many_to_many_test.exs
+++ b/test/dataloader/ecto/has_many_through_many_to_many_test.exs
@@ -89,9 +89,9 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
         %Post{user_id: user1.id, title: "unpublished_post", status: "unpublished"}
         |> Repo.insert!()
 
-      score1 = %Score{post_id: post1.id, leaderboard_id: leaderboard.id} |> Repo.insert!()
+      _score1 = %Score{post_id: post1.id, leaderboard_id: leaderboard.id} |> Repo.insert!()
       score2 = %Score{post_id: post2.id, leaderboard_id: leaderboard.id} |> Repo.insert!()
-      score3 = %Score{post_id: post3.id, leaderboard_id: leaderboard.id} |> Repo.insert!()
+      _score3 = %Score{post_id: post3.id, leaderboard_id: leaderboard.id} |> Repo.insert!()
 
       %Like{user_id: user1.id, post_id: post1.id, status: "unpublished"} |> Repo.insert!()
       %Like{user_id: user1.id, post_id: post2.id, status: "published"} |> Repo.insert!()

--- a/test/dataloader/ecto/has_many_through_many_to_many_test.exs
+++ b/test/dataloader/ecto/has_many_through_many_to_many_test.exs
@@ -1,7 +1,7 @@
 defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
   use ExUnit.Case, async: true
 
-  alias Dataloader.{User, Post, Score, Like}
+  alias Dataloader.{User, Post, Score, Like, Picture, UserPicture}
   import Ecto.Query
   alias Dataloader.TestRepo, as: Repo
 
@@ -105,6 +105,51 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
         |> Dataloader.run()
 
       assert [score2] == Dataloader.get(loader, Test, args, user1)
+    end
+
+    test "load has_many through many_to_many in second position", %{loader: loader} do
+      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id} |> Repo.insert!()
+
+      pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
+      pic2 = %Picture{url: "https://example.com/2.jpg"} |> Repo.insert!()
+
+      %UserPicture{user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+      %UserPicture{user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
+
+      args = {:user_pictures, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, leaderboard)
+        |> Dataloader.run()
+
+      assert [pic1, pic2] == Dataloader.get(loader, Test, args, leaderboard)
+    end
+
+    test "load has_many through many_to_many in second position with third assoc", %{
+      loader: loader
+    } do
+      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id} |> Repo.insert!()
+
+      pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
+      pic2 = %Picture{url: "https://example.com/2.jpg"} |> Repo.insert!()
+
+      %UserPicture{user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+      %UserPicture{user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
+
+      like1 = %Like{user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+      like2 = %Like{user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
+
+      args = {:user_pictures_likes, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, leaderboard)
+        |> Dataloader.run()
+
+      assert [like1, like2] == Dataloader.get(loader, Test, args, leaderboard)
     end
   end
 end

--- a/test/dataloader/ecto/has_many_through_many_to_many_test.exs
+++ b/test/dataloader/ecto/has_many_through_many_to_many_test.exs
@@ -127,6 +127,29 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
       assert [pic1, pic2] == Dataloader.get(loader, Test, args, leaderboard)
     end
 
+    test "load has_many through many_to_many in second position - with where on target schema and join_where on assoc schema",
+         %{loader: loader} do
+      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id} |> Repo.insert!()
+
+      pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
+      pic2 = %Picture{url: "https://example.com/2.jpg", status: "published"} |> Repo.insert!()
+      pic3 = %Picture{url: "https://example.com/3.jpg", status: "published"} |> Repo.insert!()
+
+      %UserPicture{user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+      %UserPicture{user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
+      %UserPicture{user_id: user1.id, picture_id: pic3.id, status: "published"} |> Repo.insert!()
+
+      args = {:user_pictures_published, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, leaderboard)
+        |> Dataloader.run()
+
+      assert [pic3] == Dataloader.get(loader, Test, args, leaderboard)
+    end
+
     test "load has_many through many_to_many in second position with third assoc", %{
       loader: loader
     } do

--- a/test/dataloader/ecto/has_many_through_many_to_many_test.exs
+++ b/test/dataloader/ecto/has_many_through_many_to_many_test.exs
@@ -50,5 +50,28 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
 
       assert [score1] == Dataloader.get(loader, Test, args, user1)
     end
+
+    test "load has_many through many_to_many - with where (on target schema)", %{loader: loader} do
+      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id} |> Repo.insert!()
+
+      post1 = %Post{user_id: user1.id, title: "pub_post", status: "published"} |> Repo.insert!()
+      post2 = %Post{user_id: user1.id, title: "unpub_post"} |> Repo.insert!()
+
+      score1 = %Score{post_id: post1.id, leaderboard_id: leaderboard.id} |> Repo.insert!()
+      _score2 = %Score{post_id: post2.id, leaderboard_id: leaderboard.id} |> Repo.insert!()
+
+      %Like{user_id: user1.id, post_id: post1.id} |> Repo.insert!()
+      %Like{user_id: user1.id, post_id: post2.id} |> Repo.insert!()
+
+      args = {:liked_published_posts_scores, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, user1)
+        |> Dataloader.run()
+
+      assert [score1] == Dataloader.get(loader, Test, args, user1)
+    end
   end
 end

--- a/test/dataloader/ecto/has_many_through_many_to_many_test.exs
+++ b/test/dataloader/ecto/has_many_through_many_to_many_test.exs
@@ -174,5 +174,32 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
 
       assert [like1, like2] == Dataloader.get(loader, Test, args, leaderboard)
     end
+
+    test "load has_many through many_to_many in second position with third assoc - with where on target schema and join_where on assoc schema",
+         %{loader: loader} do
+      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id} |> Repo.insert!()
+
+      pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
+      pic2 = %Picture{url: "https://example.com/2.jpg", status: "published"} |> Repo.insert!()
+      pic3 = %Picture{url: "https://example.com/3.jpg", status: "published"} |> Repo.insert!()
+
+      %UserPicture{user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+      %UserPicture{user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
+      %UserPicture{user_id: user1.id, picture_id: pic3.id, status: "published"} |> Repo.insert!()
+
+      _like1 = %Like{user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+      _like2 = %Like{user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
+      like3 = %Like{user_id: user1.id, picture_id: pic3.id} |> Repo.insert!()
+
+      args = {:user_pictures_published_likes, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, leaderboard)
+        |> Dataloader.run()
+
+      assert [like3] == Dataloader.get(loader, Test, args, leaderboard)
+    end
   end
 end

--- a/test/dataloader/ecto/has_many_through_many_to_many_test.exs
+++ b/test/dataloader/ecto/has_many_through_many_to_many_test.exs
@@ -1,7 +1,7 @@
 defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
   use ExUnit.Case, async: true
 
-  alias Dataloader.{User, Post, Score, Like, Picture, UserPicture}
+  alias Dataloader.{Leaderboard, User, Post, Score, Like, Picture, UserPicture}
   import Ecto.Query
   alias Dataloader.TestRepo, as: Repo
 
@@ -23,6 +23,22 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
     {:ok, loader: loader}
   end
 
+  defp query(Leaderboard, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    Leaderboard
+    |> limit(^limit)
+    |> join(:left, [l], s in assoc(l, :score))
+  end
+
+  defp query(User, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    User
+    |> limit(^limit)
+    |> join(:left, [u], p in assoc(u, :posts))
+  end
+
   defp query(schema, %{limit: limit}, test_pid) do
     send(test_pid, :querying)
 
@@ -32,7 +48,7 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
 
   describe "has_many through many-to-many associations" do
     test "load has_many through many_to_many", %{loader: loader} do
-      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      leaderboard = %Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
       user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id} |> Repo.insert!()
 
       post1 = %Post{user_id: user1.id, title: "foo"} |> Repo.insert!()
@@ -52,7 +68,7 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
     end
 
     test "load has_many through many_to_many - with where on target schema", %{loader: loader} do
-      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      leaderboard = %Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
       user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id} |> Repo.insert!()
 
       post1 = %Post{user_id: user1.id, title: "pub_post", status: "published"} |> Repo.insert!()
@@ -76,7 +92,7 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
 
     test "load has_many through many_to_many - with where on target schema and join_where on assoc schema",
          %{loader: loader} do
-      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      leaderboard = %Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
       user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id} |> Repo.insert!()
 
       post1 =
@@ -108,7 +124,7 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
     end
 
     test "load has_many through many_to_many in second position", %{loader: loader} do
-      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      leaderboard = %Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
       user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id} |> Repo.insert!()
 
       pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
@@ -129,7 +145,7 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
 
     test "load has_many through many_to_many in second position - with where on target schema and join_where on assoc schema",
          %{loader: loader} do
-      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      leaderboard = %Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
       user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id} |> Repo.insert!()
 
       pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
@@ -153,7 +169,7 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
     test "load has_many through many_to_many in second position with third assoc", %{
       loader: loader
     } do
-      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      leaderboard = %Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
       user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id} |> Repo.insert!()
 
       pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
@@ -177,7 +193,7 @@ defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
 
     test "load has_many through many_to_many in second position with third assoc - with where on target schema and join_where on assoc schema",
          %{loader: loader} do
-      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      leaderboard = %Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
       user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id} |> Repo.insert!()
 
       pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()

--- a/test/dataloader/ecto/has_many_through_many_to_many_test.exs
+++ b/test/dataloader/ecto/has_many_through_many_to_many_test.exs
@@ -1,0 +1,54 @@
+defmodule Dataloader.Ecto.HasManyThroughManyToManyTest do
+  use ExUnit.Case, async: true
+
+  alias Dataloader.{User, Post, Score, Like}
+  import Ecto.Query
+  alias Dataloader.TestRepo, as: Repo
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+    test_pid = self()
+
+    source =
+      Dataloader.Ecto.new(
+        Repo,
+        query: &query(&1, &2, test_pid)
+      )
+
+    loader =
+      Dataloader.new()
+      |> Dataloader.add_source(Test, source)
+
+    {:ok, loader: loader}
+  end
+
+  defp query(schema, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    schema
+    |> limit(^limit)
+  end
+
+  describe "has_many through mant-to-many associations" do
+    test "load has_many through many_to_many", %{loader: loader} do
+      leaderboard = %Dataloader.Leaderboard{name: "Top Bloggers"} |> Repo.insert!()
+      user1 = %User{username: "Ben Wilson", leaderboard_id: leaderboard.id } |> Repo.insert!()
+
+      post1 = %Post{user_id: user1.id, title: "foo"} |> Repo.insert!()
+
+      score1 = %Score{post_id: post1.id, leaderboard_id: leaderboard.id} |> Repo.insert!()
+
+      %Like{user_id: user1.id, post_id: post1.id} |> Repo.insert!()
+
+      args = {:liked_posts_scores, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, user1)
+        |> Dataloader.run()
+
+      assert [score1] == Dataloader.get(loader, Test, args, user1)
+    end
+  end
+end

--- a/test/dataloader/ecto/has_many_where_test.exs
+++ b/test/dataloader/ecto/has_many_where_test.exs
@@ -1,7 +1,7 @@
 defmodule Dataloader.Ecto.HasManyWhereTest do
   use ExUnit.Case, async: true
 
-  alias Dataloader.{User, Post}
+  alias Dataloader.{User, Post, Like}
   import Ecto.Query
   alias Dataloader.TestRepo, as: Repo
 
@@ -31,7 +31,7 @@ defmodule Dataloader.Ecto.HasManyWhereTest do
   end
 
   describe "where in has-many associations" do
-    test "compare value", %{loader: loader} do
+    test "simple filtered has_many", %{loader: loader} do
       user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
 
       post1 = %Post{user_id: user1.id, title: "foo", status: "published"} |> Repo.insert!()
@@ -45,6 +45,25 @@ defmodule Dataloader.Ecto.HasManyWhereTest do
         |> Dataloader.run()
 
       assert [post1] == Dataloader.get(loader, Test, args, user1)
+    end
+
+    test "simple filtered has_many in has_many through in first position", %{loader: loader} do
+      user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+
+      post1 = %Post{user_id: user1.id, title: "foo", status: "published"} |> Repo.insert!()
+      post2 = %Post{user_id: user1.id, title: "bar", status: "unpublished"} |> Repo.insert!()
+
+      like1 = %Like{user_id: user1.id, post_id: post1.id} |> Repo.insert!()
+      _like2 = %Like{user_id: user1.id, post_id: post2.id} |> Repo.insert!()
+
+      args = {:published_posts_likes, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, user1)
+        |> Dataloader.run()
+
+      assert [like1] == Dataloader.get(loader, Test, args, user1)
     end
   end
 end

--- a/test/dataloader/ecto/has_many_where_test.exs
+++ b/test/dataloader/ecto/has_many_where_test.exs
@@ -1,0 +1,50 @@
+defmodule Dataloader.Ecto.HasManyWhereTest do
+  use ExUnit.Case, async: true
+
+  alias Dataloader.{User, Post}
+  import Ecto.Query
+  alias Dataloader.TestRepo, as: Repo
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+    test_pid = self()
+
+    source =
+      Dataloader.Ecto.new(
+        Repo,
+        query: &query(&1, &2, test_pid)
+      )
+
+    loader =
+      Dataloader.new()
+      |> Dataloader.add_source(Test, source)
+
+    {:ok, loader: loader}
+  end
+
+  defp query(schema, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    schema
+    |> limit(^limit)
+  end
+
+  describe "where in has-many associations" do
+    test "compare value", %{loader: loader} do
+      user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+
+      post1 = %Post{user_id: user1.id, title: "foo", status: "published"} |> Repo.insert!()
+      _post2 = %Post{user_id: user1.id, title: "bar", status: "unpublished"} |> Repo.insert!()
+
+      args = {:published_posts, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, user1)
+        |> Dataloader.run()
+
+      assert [post1] == Dataloader.get(loader, Test, args, user1)
+    end
+  end
+end

--- a/test/dataloader/ecto/has_many_where_test.exs
+++ b/test/dataloader/ecto/has_many_where_test.exs
@@ -23,11 +23,28 @@ defmodule Dataloader.Ecto.HasManyWhereTest do
     {:ok, loader: loader}
   end
 
+  defp query(Like, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    Like
+    |> limit(^limit)
+    |> join(:left, [l], u in User, on: l.user_id == u.id)
+  end
+
+  defp query(Post, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    Post
+    |> limit(^limit)
+    |> join(:left, [p], s in assoc(p, :scores))
+  end
+
   defp query(schema, %{limit: limit}, test_pid) do
     send(test_pid, :querying)
 
     schema
     |> limit(^limit)
+    |> join(:left, [p], s in assoc(p, :scores))
   end
 
   describe "where in has-many associations" do

--- a/test/dataloader/ecto/many_to_many_join_where_test.exs
+++ b/test/dataloader/ecto/many_to_many_join_where_test.exs
@@ -1,0 +1,62 @@
+defmodule Dataloader.Ecto.ManyToManyJoinWhereTest do
+  use ExUnit.Case, async: true
+
+  alias Dataloader.{User, Picture, UserPicture}
+  import Ecto.Query
+  alias Dataloader.TestRepo, as: Repo
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+    test_pid = self()
+
+    source =
+      Dataloader.Ecto.new(
+        Repo,
+        query: &query(&1, &2, test_pid)
+      )
+
+    loader =
+      Dataloader.new()
+      |> Dataloader.add_source(Test, source)
+
+    {:ok, loader: loader}
+  end
+
+  defp query(User, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    User
+    |> from(as: :user)
+    |> limit(^limit)
+  end
+
+  defp query(schema, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    schema
+    |> limit(^limit)
+  end
+
+  test ":join_where is filtering associated entities", %{loader: loader} do
+    user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+
+    pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
+    pic2 = %Picture{url: "https://example.com/2.jpg"} |> Repo.insert!()
+    pic3 = %Picture{url: "https://example.com/3.jpg"} |> Repo.insert!()
+
+
+    %UserPicture{status: "published", user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+    %UserPicture{status: "published", user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
+    %UserPicture{status: "unpublished", user_id: user1.id, picture_id: pic3.id} |> Repo.insert!()
+
+    args = {:pictures, %{limit: 10}}
+
+    loader =
+      loader
+      |> Dataloader.load(Test, args, user1)
+      |> Dataloader.run()
+
+    assert [pic1, pic2] == Dataloader.get(loader, Test, args, user1)
+  end
+end

--- a/test/dataloader/ecto/many_to_many_join_where_test.exs
+++ b/test/dataloader/ecto/many_to_many_join_where_test.exs
@@ -38,25 +38,93 @@ defmodule Dataloader.Ecto.ManyToManyJoinWhereTest do
     |> limit(^limit)
   end
 
-  test ":join_where is filtering associated entities", %{loader: loader} do
-    user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+  describe "join_where in mant-to-many associations" do
+    test "compare value", %{loader: loader} do
+      user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
 
-    pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
-    pic2 = %Picture{url: "https://example.com/2.jpg"} |> Repo.insert!()
-    pic3 = %Picture{url: "https://example.com/3.jpg"} |> Repo.insert!()
+      pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
+      pic2 = %Picture{url: "https://example.com/2.jpg"} |> Repo.insert!()
 
+      %UserPicture{status: "published", user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
 
-    %UserPicture{status: "published", user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
-    %UserPicture{status: "published", user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
-    %UserPicture{status: "unpublished", user_id: user1.id, picture_id: pic3.id} |> Repo.insert!()
+      %UserPicture{status: "unpublished", user_id: user1.id, picture_id: pic2.id}
+      |> Repo.insert!()
 
-    args = {:pictures, %{limit: 10}}
+      args = {:pictures_join_compare_value, %{limit: 10}}
 
-    loader =
-      loader
-      |> Dataloader.load(Test, args, user1)
-      |> Dataloader.run()
+      loader =
+        loader
+        |> Dataloader.load(Test, args, user1)
+        |> Dataloader.run()
 
-    assert [pic1, pic2] == Dataloader.get(loader, Test, args, user1)
+      assert [pic1] == Dataloader.get(loader, Test, args, user1)
+    end
+
+    test "is nil", %{loader: loader} do
+      user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+
+      pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
+      pic2 = %Picture{url: "https://example.com/2.jpg"} |> Repo.insert!()
+
+      %UserPicture{status: nil, user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+
+      %UserPicture{status: "unpublished", user_id: user1.id, picture_id: pic2.id}
+      |> Repo.insert!()
+
+      args = {:pictures_join_nil, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, user1)
+        |> Dataloader.run()
+
+      assert [pic1] == Dataloader.get(loader, Test, args, user1)
+    end
+
+    test "in list", %{loader: loader} do
+      user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+
+      pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
+      pic2 = %Picture{url: "https://example.com/2.jpg"} |> Repo.insert!()
+      pic3 = %Picture{url: "https://example.com/3.jpg"} |> Repo.insert!()
+
+      %UserPicture{status: "published", user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+
+      %UserPicture{status: "unpublished", user_id: user1.id, picture_id: pic2.id}
+      |> Repo.insert!()
+
+      %UserPicture{status: "blurry", user_id: user1.id, picture_id: pic3.id}
+      |> Repo.insert!()
+
+      args = {:pictures_join_in, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, user1)
+        |> Dataloader.run()
+
+      assert [pic1, pic3] == Dataloader.get(loader, Test, args, user1)
+    end
+
+    test "fragment", %{loader: loader} do
+      user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+
+      pic1 = %Picture{url: "https://example.com/1.jpg"} |> Repo.insert!()
+      pic2 = %Picture{url: "https://example.com/2.jpg"} |> Repo.insert!()
+      pic3 = %Picture{url: "https://example.com/3.jpg"} |> Repo.insert!()
+
+      %UserPicture{status: "pub", user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+      %UserPicture{status: "unpub", user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
+      %UserPicture{status: "pub", user_id: user1.id, picture_id: pic3.id} |> Repo.insert!()
+
+      args = {:pictures_join_fragment, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, user1)
+        |> Dataloader.run()
+
+      assert [pic2] == Dataloader.get(loader, Test, args, user1)
+    end
   end
 end

--- a/test/dataloader/ecto/many_to_many_join_where_test.exs
+++ b/test/dataloader/ecto/many_to_many_join_where_test.exs
@@ -23,14 +23,6 @@ defmodule Dataloader.Ecto.ManyToManyJoinWhereTest do
     {:ok, loader: loader}
   end
 
-  defp query(User, %{limit: limit}, test_pid) do
-    send(test_pid, :querying)
-
-    User
-    |> from(as: :user)
-    |> limit(^limit)
-  end
-
   defp query(schema, %{limit: limit}, test_pid) do
     send(test_pid, :querying)
 

--- a/test/dataloader/ecto/many_to_many_join_where_test.exs
+++ b/test/dataloader/ecto/many_to_many_join_where_test.exs
@@ -30,7 +30,7 @@ defmodule Dataloader.Ecto.ManyToManyJoinWhereTest do
     |> limit(^limit)
   end
 
-  describe "join_where in mant-to-many associations" do
+  describe "join_where in many-to-many associations" do
     test "compare value", %{loader: loader} do
       user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
 

--- a/test/dataloader/ecto/many_to_many_where_test.exs
+++ b/test/dataloader/ecto/many_to_many_where_test.exs
@@ -30,7 +30,7 @@ defmodule Dataloader.Ecto.ManyToManyWhereTest do
     |> limit(^limit)
   end
 
-  describe "where in mant-to-many associations" do
+  describe "where in many-to-many associations" do
     test "compare value", %{loader: loader} do
       user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
 

--- a/test/dataloader/ecto/many_to_many_where_test.exs
+++ b/test/dataloader/ecto/many_to_many_where_test.exs
@@ -23,14 +23,6 @@ defmodule Dataloader.Ecto.ManyToManyWhereTest do
     {:ok, loader: loader}
   end
 
-  defp query(User, %{limit: limit}, test_pid) do
-    send(test_pid, :querying)
-
-    User
-    |> from(as: :user)
-    |> limit(^limit)
-  end
-
   defp query(schema, %{limit: limit}, test_pid) do
     send(test_pid, :querying)
 

--- a/test/dataloader/ecto/many_to_many_where_test.exs
+++ b/test/dataloader/ecto/many_to_many_where_test.exs
@@ -1,0 +1,122 @@
+defmodule Dataloader.Ecto.ManyToManyWhereTest do
+  use ExUnit.Case, async: true
+
+  alias Dataloader.{User, Picture, UserPicture}
+  import Ecto.Query
+  alias Dataloader.TestRepo, as: Repo
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+
+    test_pid = self()
+
+    source =
+      Dataloader.Ecto.new(
+        Repo,
+        query: &query(&1, &2, test_pid)
+      )
+
+    loader =
+      Dataloader.new()
+      |> Dataloader.add_source(Test, source)
+
+    {:ok, loader: loader}
+  end
+
+  defp query(User, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    User
+    |> from(as: :user)
+    |> limit(^limit)
+  end
+
+  defp query(schema, %{limit: limit}, test_pid) do
+    send(test_pid, :querying)
+
+    schema
+    |> limit(^limit)
+  end
+
+  describe "where in mant-to-many associations" do
+    test "compare value", %{loader: loader} do
+      user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+
+      pic1 = %Picture{status: "published", url: "https://example.com/1.jpg"} |> Repo.insert!()
+      pic2 = %Picture{status: "unpublished", url: "https://example.com/2.jpg"} |> Repo.insert!()
+
+      %UserPicture{user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+      %UserPicture{user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
+
+      args = {:pictures_compare_value, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, user1)
+        |> Dataloader.run()
+
+      assert [pic1] == Dataloader.get(loader, Test, args, user1)
+    end
+
+    test "is nil", %{loader: loader} do
+      user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+
+      pic1 = %Picture{status: "published", url: "https://example.com/1.jpg"} |> Repo.insert!()
+      pic2 = %Picture{status: nil, url: "https://example.com/2.jpg"} |> Repo.insert!()
+
+      %UserPicture{user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+      %UserPicture{user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
+
+      args = {:pictures_nil, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, user1)
+        |> Dataloader.run()
+
+      assert [pic2] == Dataloader.get(loader, Test, args, user1)
+    end
+
+    test "in list", %{loader: loader} do
+      user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+
+      pic1 = %Picture{status: "one", url: "https://example.com/1.jpg"} |> Repo.insert!()
+      pic2 = %Picture{status: "published", url: "https://example.com/2.jpg"} |> Repo.insert!()
+      pic3 = %Picture{status: "blurry", url: "https://example.com/3.jpg"} |> Repo.insert!()
+
+      %UserPicture{user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+      %UserPicture{user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
+      %UserPicture{user_id: user1.id, picture_id: pic3.id} |> Repo.insert!()
+
+      args = {:pictures_in, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, user1)
+        |> Dataloader.run()
+
+      assert [pic2, pic3] == Dataloader.get(loader, Test, args, user1)
+    end
+
+    test "fragment", %{loader: loader} do
+      user1 = %User{username: "Ben Wilson"} |> Repo.insert!()
+
+      pic1 = %Picture{status: "pub", url: "https://example.com/1.jpg"} |> Repo.insert!()
+      pic2 = %Picture{status: "unpub", url: "https://example.com/2.jpg"} |> Repo.insert!()
+      pic3 = %Picture{status: "pub", url: "https://example.com/3.jpg"} |> Repo.insert!()
+
+      %UserPicture{user_id: user1.id, picture_id: pic1.id} |> Repo.insert!()
+      %UserPicture{user_id: user1.id, picture_id: pic2.id} |> Repo.insert!()
+      %UserPicture{user_id: user1.id, picture_id: pic3.id} |> Repo.insert!()
+
+      args = {:pictures_fragment, %{limit: 10}}
+
+      loader =
+        loader
+        |> Dataloader.load(Test, args, user1)
+        |> Dataloader.run()
+
+      assert [pic2] == Dataloader.get(loader, Test, args, user1)
+    end
+  end
+end

--- a/test/support/leaderboard.ex
+++ b/test/support/leaderboard.ex
@@ -4,5 +4,8 @@ defmodule Dataloader.Leaderboard do
   schema "leaderboards" do
     field(:name, :string)
     has_many(:scores, Dataloader.Score)
+    has_many(:users, Dataloader.User)
+    has_many(:user_pictures, through: [:users, :pictures])
+    has_many(:user_pictures_likes, through: [:users, :pictures, :likes])
   end
 end

--- a/test/support/leaderboard.ex
+++ b/test/support/leaderboard.ex
@@ -8,5 +8,6 @@ defmodule Dataloader.Leaderboard do
     has_many(:user_pictures, through: [:users, :pictures])
     has_many(:user_pictures_published, through: [:users, :pictures_published])
     has_many(:user_pictures_likes, through: [:users, :pictures, :likes])
+    has_many(:user_pictures_published_likes, through: [:users, :pictures_published, :likes])
   end
 end

--- a/test/support/leaderboard.ex
+++ b/test/support/leaderboard.ex
@@ -6,6 +6,7 @@ defmodule Dataloader.Leaderboard do
     has_many(:scores, Dataloader.Score)
     has_many(:users, Dataloader.User)
     has_many(:user_pictures, through: [:users, :pictures])
+    has_many(:user_pictures_published, through: [:users, :pictures_published])
     has_many(:user_pictures_likes, through: [:users, :pictures, :likes])
   end
 end

--- a/test/support/leaderboard.ex
+++ b/test/support/leaderboard.ex
@@ -9,5 +9,6 @@ defmodule Dataloader.Leaderboard do
     has_many(:user_pictures_published, through: [:users, :pictures_published])
     has_many(:user_pictures_likes, through: [:users, :pictures, :likes])
     has_many(:user_pictures_published_likes, through: [:users, :pictures_published, :likes])
+    has_many(:user_published_posts_likes, through: [:users, :published_posts, :likes])
   end
 end

--- a/test/support/like.ex
+++ b/test/support/like.ex
@@ -4,5 +4,6 @@ defmodule Dataloader.Like do
   schema "likes" do
     belongs_to(:user, Dataloader.User)
     belongs_to(:post, Dataloader.Post)
+    field(:status, :string)
   end
 end

--- a/test/support/like.ex
+++ b/test/support/like.ex
@@ -3,7 +3,7 @@ defmodule Dataloader.Like do
 
   schema "likes" do
     belongs_to(:user, Dataloader.User)
-    belongs_to(:post, Dataloader.Post)
+    belongs_to(:post, Dataloader.Post, where: [status: "published"])
     belongs_to(:picture, Dataloader.Picture)
     field(:status, :string)
   end

--- a/test/support/like.ex
+++ b/test/support/like.ex
@@ -4,6 +4,7 @@ defmodule Dataloader.Like do
   schema "likes" do
     belongs_to(:user, Dataloader.User)
     belongs_to(:post, Dataloader.Post)
+    belongs_to(:picture, Dataloader.Picture)
     field(:status, :string)
   end
 end

--- a/test/support/picture.ex
+++ b/test/support/picture.ex
@@ -4,5 +4,6 @@ defmodule Dataloader.Picture do
   schema "pictures" do
     field(:status, :string)
     field(:url, :string, null: false)
+    has_many(:likes, Dataloader.Like)
   end
 end

--- a/test/support/picture.ex
+++ b/test/support/picture.ex
@@ -1,0 +1,7 @@
+defmodule Dataloader.Picture do
+  use Ecto.Schema
+
+  schema "pictures" do
+    field :url, :string, null: false
+  end
+end

--- a/test/support/picture.ex
+++ b/test/support/picture.ex
@@ -5,5 +5,6 @@ defmodule Dataloader.Picture do
     field(:status, :string)
     field(:url, :string, null: false)
     has_many(:likes, Dataloader.Like)
+    has_many(:published_likes, Dataloader.Like, where: [status: "published"])
   end
 end

--- a/test/support/picture.ex
+++ b/test/support/picture.ex
@@ -2,6 +2,7 @@ defmodule Dataloader.Picture do
   use Ecto.Schema
 
   schema "pictures" do
-    field :url, :string, null: false
+    field(:status, :string)
+    field(:url, :string, null: false)
   end
 end

--- a/test/support/post.ex
+++ b/test/support/post.ex
@@ -8,6 +8,7 @@ defmodule Dataloader.Post do
     has_many(:liking_users, through: [:likes, :user])
 
     field(:title, :string)
+    field(:status, :string)
     field(:deleted_at, :utc_datetime)
   end
 end

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -4,6 +4,7 @@ defmodule Dataloader.User do
   schema "users" do
     field(:username, :string)
     has_many(:posts, Dataloader.Post)
+    has_many(:published_posts, Dataloader.Post, where: [status: "published"])
     belongs_to(:leaderboard, Dataloader.Leaderboard)
 
     has_many(:scores, through: [:posts, :scores])

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -31,51 +31,45 @@ defmodule Dataloader.User do
       through: [:published_liked_published_posts, :scores]
     )
 
+    many_to_many(:pictures, Dataloader.Picture, join_through: Dataloader.UserPicture)
+
     many_to_many(:pictures_join_compare_value, Dataloader.Picture,
       join_through: Dataloader.UserPicture,
-      join_keys: [user_id: :id, picture_id: :id],
       join_where: [status: "published"]
     )
 
     many_to_many(:pictures_join_nil, Dataloader.Picture,
       join_through: Dataloader.UserPicture,
-      join_keys: [user_id: :id, picture_id: :id],
       join_where: [status: nil]
     )
 
     many_to_many(:pictures_join_in, Dataloader.Picture,
       join_through: Dataloader.UserPicture,
-      join_keys: [user_id: :id, picture_id: :id],
       join_where: [status: {:in, ["published", "blurry"]}]
     )
 
     many_to_many(:pictures_join_fragment, Dataloader.Picture,
       join_through: Dataloader.UserPicture,
-      join_keys: [user_id: :id, picture_id: :id],
       join_where: [status: {:fragment, "LENGTH(?) > 3"}]
     )
 
     many_to_many(:pictures_compare_value, Dataloader.Picture,
       join_through: Dataloader.UserPicture,
-      join_keys: [user_id: :id, picture_id: :id],
       where: [status: "published"]
     )
 
     many_to_many(:pictures_nil, Dataloader.Picture,
       join_through: Dataloader.UserPicture,
-      join_keys: [user_id: :id, picture_id: :id],
       where: [status: nil]
     )
 
     many_to_many(:pictures_in, Dataloader.Picture,
       join_through: Dataloader.UserPicture,
-      join_keys: [user_id: :id, picture_id: :id],
       where: [status: {:in, ["published", "blurry"]}]
     )
 
     many_to_many(:pictures_fragment, Dataloader.Picture,
       join_through: Dataloader.UserPicture,
-      join_keys: [user_id: :id, picture_id: :id],
       where: [status: {:fragment, "LENGTH(?) > 3"}]
     )
   end

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -10,9 +10,16 @@ defmodule Dataloader.User do
     has_many(:awarded_posts, through: [:scores, :post])
     has_many(:likes, through: [:awarded_posts, :likes])
     many_to_many(:liked_posts, Dataloader.Post, join_through: Dataloader.Like)
+
+    many_to_many(:liked_published_posts, Dataloader.Post,
+      join_through: Dataloader.Like,
+      where: [status: "published"]
+    )
+
     has_many(:fans, through: [:likes, :user])
 
     has_many(:liked_posts_scores, through: [:liked_posts, :scores])
+    has_many(:liked_published_posts_scores, through: [:liked_published_posts, :scores])
 
     many_to_many(:pictures_join_compare_value, Dataloader.Picture,
       join_through: Dataloader.UserPicture,

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -36,6 +36,8 @@ defmodule Dataloader.User do
 
     many_to_many(:pictures, Dataloader.Picture, join_through: Dataloader.UserPicture)
 
+    has_many(:published_picture_likes, through: [:pictures, :published_likes])
+
     many_to_many(:pictures_published, Dataloader.Picture,
       join_through: Dataloader.UserPicture,
       join_where: [status: "published"],

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -5,11 +5,13 @@ defmodule Dataloader.User do
     field(:username, :string)
     has_many(:posts, Dataloader.Post)
     has_many(:published_posts, Dataloader.Post, where: [status: "published"])
+    has_many(:published_posts_likes, through: [:published_posts, :likes])
     belongs_to(:leaderboard, Dataloader.Leaderboard)
 
     has_many(:scores, through: [:posts, :scores])
     has_many(:awarded_posts, through: [:scores, :post])
     has_many(:likes, through: [:awarded_posts, :likes])
+
     many_to_many(:liked_posts, Dataloader.Post, join_through: Dataloader.Like)
 
     many_to_many(:liked_published_posts, Dataloader.Post,

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -11,5 +11,10 @@ defmodule Dataloader.User do
     has_many(:likes, through: [:awarded_posts, :likes])
     many_to_many(:liked_posts, Dataloader.Post, join_through: Dataloader.Like)
     has_many(:fans, through: [:likes, :user])
+    many_to_many(:pictures, Dataloader.Picture,
+      join_through: Dataloader.UserPicture,
+      join_keys: [user_id: :id, picture_id: :id],
+      join_where: [status: "published"]
+    )
   end
 end

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -11,10 +11,53 @@ defmodule Dataloader.User do
     has_many(:likes, through: [:awarded_posts, :likes])
     many_to_many(:liked_posts, Dataloader.Post, join_through: Dataloader.Like)
     has_many(:fans, through: [:likes, :user])
-    many_to_many(:pictures, Dataloader.Picture,
+
+    many_to_many(:pictures_join_compare_value, Dataloader.Picture,
       join_through: Dataloader.UserPicture,
       join_keys: [user_id: :id, picture_id: :id],
       join_where: [status: "published"]
+    )
+
+    many_to_many(:pictures_join_nil, Dataloader.Picture,
+      join_through: Dataloader.UserPicture,
+      join_keys: [user_id: :id, picture_id: :id],
+      join_where: [status: nil]
+    )
+
+    many_to_many(:pictures_join_in, Dataloader.Picture,
+      join_through: Dataloader.UserPicture,
+      join_keys: [user_id: :id, picture_id: :id],
+      join_where: [status: {:in, ["published", "blurry"]}]
+    )
+
+    many_to_many(:pictures_join_fragment, Dataloader.Picture,
+      join_through: Dataloader.UserPicture,
+      join_keys: [user_id: :id, picture_id: :id],
+      join_where: [status: {:fragment, "LENGTH(?) > 3"}]
+    )
+
+    many_to_many(:pictures_compare_value, Dataloader.Picture,
+      join_through: Dataloader.UserPicture,
+      join_keys: [user_id: :id, picture_id: :id],
+      where: [status: "published"]
+    )
+
+    many_to_many(:pictures_nil, Dataloader.Picture,
+      join_through: Dataloader.UserPicture,
+      join_keys: [user_id: :id, picture_id: :id],
+      where: [status: nil]
+    )
+
+    many_to_many(:pictures_in, Dataloader.Picture,
+      join_through: Dataloader.UserPicture,
+      join_keys: [user_id: :id, picture_id: :id],
+      where: [status: {:in, ["published", "blurry"]}]
+    )
+
+    many_to_many(:pictures_fragment, Dataloader.Picture,
+      join_through: Dataloader.UserPicture,
+      join_keys: [user_id: :id, picture_id: :id],
+      where: [status: {:fragment, "LENGTH(?) > 3"}]
     )
   end
 end

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -16,10 +16,20 @@ defmodule Dataloader.User do
       where: [status: "published"]
     )
 
+    many_to_many(:published_liked_published_posts, Dataloader.Post,
+      join_through: Dataloader.Like,
+      where: [status: "published"],
+      join_where: [status: "published"]
+    )
+
     has_many(:fans, through: [:likes, :user])
 
     has_many(:liked_posts_scores, through: [:liked_posts, :scores])
     has_many(:liked_published_posts_scores, through: [:liked_published_posts, :scores])
+
+    has_many(:published_liked_published_posts_scores,
+      through: [:published_liked_published_posts, :scores]
+    )
 
     many_to_many(:pictures_join_compare_value, Dataloader.Picture,
       join_through: Dataloader.UserPicture,

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -33,6 +33,12 @@ defmodule Dataloader.User do
 
     many_to_many(:pictures, Dataloader.Picture, join_through: Dataloader.UserPicture)
 
+    many_to_many(:pictures_published, Dataloader.Picture,
+      join_through: Dataloader.UserPicture,
+      join_where: [status: "published"],
+      where: [status: "published"]
+    )
+
     many_to_many(:pictures_join_compare_value, Dataloader.Picture,
       join_through: Dataloader.UserPicture,
       join_where: [status: "published"]

--- a/test/support/user.ex
+++ b/test/support/user.ex
@@ -12,6 +12,8 @@ defmodule Dataloader.User do
     many_to_many(:liked_posts, Dataloader.Post, join_through: Dataloader.Like)
     has_many(:fans, through: [:likes, :user])
 
+    has_many(:liked_posts_scores, through: [:liked_posts, :scores])
+
     many_to_many(:pictures_join_compare_value, Dataloader.Picture,
       join_through: Dataloader.UserPicture,
       join_keys: [user_id: :id, picture_id: :id],

--- a/test/support/user_picture.ex
+++ b/test/support/user_picture.ex
@@ -1,0 +1,9 @@
+defmodule Dataloader.UserPicture do
+  use Ecto.Schema
+
+  schema "user_pictures" do
+    field :status, :string, default: "unpublished"
+    belongs_to(:picture, Dataloader.Picture)
+    belongs_to(:user, Dataloader.User)
+  end
+end

--- a/test/support/user_picture.ex
+++ b/test/support/user_picture.ex
@@ -2,7 +2,7 @@ defmodule Dataloader.UserPicture do
   use Ecto.Schema
 
   schema "user_pictures" do
-    field :status, :string, default: "unpublished"
+    field(:status, :string)
     belongs_to(:picture, Dataloader.Picture)
     belongs_to(:user, Dataloader.User)
   end


### PR DESCRIPTION
We're using dataloader with a schema that has `where` and `join_where` clauses in many-to-many relationships.

Before this, these clauses where ignored.