### PR TITLE
improvement: add async?/1 to source protocol

### DIFF
--- a/lib/dataloader.ex
+++ b/lib/dataloader.ex
@@ -154,14 +154,18 @@ defmodule Dataloader do
         |> Enum.split_with(fn {_name, source} -> Dataloader.Source.async?(source) end)
 
       async_source_results =
-        async_safely(__MODULE__, :run_tasks, [
-          async_sources,
-          fun,
+        async_safely(
+          __MODULE__,
+          :run_tasks,
           [
-            timeout: dataloader_timeout(dataloader),
-            async?: true
-          ]
-        ])
+            async_sources,
+            fun,
+            [
+              timeout: dataloader_timeout(dataloader)
+            ]
+          ],
+          async?: true
+        )
 
       sync_source_results =
         async_safely(
@@ -171,8 +175,7 @@ defmodule Dataloader do
             sync_sources,
             fun,
             [
-              timeout: dataloader_timeout(dataloader),
-              async?: false
+              timeout: dataloader_timeout(dataloader)
             ]
           ],
           async?: false

--- a/lib/dataloader.ex
+++ b/lib/dataloader.ex
@@ -149,13 +149,39 @@ defmodule Dataloader do
 
       emit_start_event(id, system_time, dataloader)
 
-      sources =
+      {async_sources, sync_sources} =
+        dataloader.sources
+        |> Enum.split_with(fn {_name, source} -> Dataloader.Source.async?(source) end)
+
+      async_source_results =
         async_safely(__MODULE__, :run_tasks, [
-          dataloader.sources,
+          async_sources,
           fun,
-          [timeout: dataloader_timeout(dataloader)]
+          [
+            timeout: dataloader_timeout(dataloader),
+            async?: true
+          ]
         ])
-        |> Enum.map(fn
+
+      sync_source_results =
+        async_safely(
+          __MODULE__,
+          :run_tasks,
+          [
+            sync_sources,
+            fun,
+            [
+              timeout: dataloader_timeout(dataloader),
+              async?: false
+            ]
+          ],
+          async?: false
+        )
+
+      sources =
+        async_source_results
+        |> Stream.concat(sync_source_results)
+        |> Stream.map(fn
           {_source, {:ok, {name, source}}} -> {name, source}
           {_source, {:error, reason}} -> {:error, reason}
         end)
@@ -267,24 +293,33 @@ defmodule Dataloader do
   whatever that returns.
   """
   @spec async_safely(module(), atom(), list()) :: any()
-  def async_safely(mod, fun, args \\ []) do
-    # The intermediary task is spawned here so that the `:trap_exit` flag does
-    # not lead to rogue behaviour within the current process. This could happen
-    # if the current process is linked to something, and then that something
-    # dies in the middle of us loading stuff.
-    task =
-      Task.async(fn ->
-        # The purpose of `:trap_exit` here is so that we can ensure that any failures
-        # within the tasks do not kill the current process. We want to get results
-        # back no matter what.
-        Process.flag(:trap_exit, true)
+  def async_safely(mod, fun, args \\ [], opts \\ []) do
+    if Keyword.get(opts, :async?, true) do
+      # The intermediary task is spawned here so that the `:trap_exit` flag does
+      # not lead to rogue behaviour within the current process. This could happen
+      # if the current process is linked to something, and then that something
+      # dies in the middle of us loading stuff.
+      task =
+        Task.async(fn ->
+          # The purpose of `:trap_exit` here is so that we can ensure that any failures
+          # within the tasks do not kill the current process. We want to get results
+          # back no matter what.
+          Process.flag(:trap_exit, true)
 
+          apply(mod, fun, args)
+        end)
+
+      # The infinity is safe here because the internal
+      # tasks all have their own timeout.
+      Task.await(task, :infinity)
+    else
+      try do
         apply(mod, fun, args)
-      end)
-
-    # The infinity is safe here because the internal
-    # tasks all have their own timeout.
-    Task.await(task, :infinity)
+      rescue
+        exception ->
+          {:exit, exception}
+      end
+    end
   end
 
   @doc ~S"""
@@ -306,6 +341,8 @@ defmodule Dataloader do
         2 => {:error, :timeout},
         3 => {:error, :timeout}
       }
+
+  By default, tasks are run asynchronously. To run them synchronously, provide `async?: false`.
   """
   @spec run_tasks(list(), fun(), keyword()) :: map()
   def run_tasks(items, fun, opts \\ []) do
@@ -316,12 +353,18 @@ defmodule Dataloader do
       |> Keyword.put(:on_timeout, :kill_task)
 
     results =
-      items
-      |> Task.async_stream(fun, task_opts)
-      |> Enum.map(fn
-        {:ok, result} -> {:ok, result}
-        {:exit, reason} -> {:error, reason}
-      end)
+      if Keyword.get(opts, :async?, true) do
+        items
+        |> Task.async_stream(fun, task_opts)
+        |> Enum.map(fn
+          {:ok, result} -> {:ok, result}
+          {:exit, reason} -> {:error, reason}
+        end)
+      else
+        Enum.map(items, fn item ->
+          {:ok, fun.(item)}
+        end)
+      end
 
     Enum.zip(items, results)
     |> Map.new()

--- a/lib/dataloader/source.ex
+++ b/lib/dataloader/source.ex
@@ -44,7 +44,7 @@ defprotocol Dataloader.Source do
   def timeout(source)
 
   @doc """
-  Returns wether or not the source should be running synchronously or asynchronously
+  Returns whether or not the source should be running synchronously or asynchronously with respect to the process making `Dataloader` function calls.
   """
   @spec async?(t) :: boolean
   def async?(source)

--- a/lib/dataloader/source.ex
+++ b/lib/dataloader/source.ex
@@ -42,4 +42,10 @@ defprotocol Dataloader.Source do
   """
   @spec timeout(t) :: number
   def timeout(source)
+
+  @doc """
+  Returns wether or not the source should be running synchronously or asynchronously
+  """
+  @spec async?(t) :: boolean
+  def async?(source)
 end

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -369,9 +369,7 @@ defmodule Dataloader.EctoTest do
         ordered_usernames = Enum.map(loaded_posts, & &1.username)
 
         assert ordered_usernames == expected_usernames,
-               "got #{inspect(ordered_usernames)} but was expecting #{inspect(expected_usernames)} for sort_order #{
-                 sort_order
-               }"
+               "got #{inspect(ordered_usernames)} but was expecting #{inspect(expected_usernames)} for sort_order #{sort_order}"
       end
     end
 

--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -369,7 +369,9 @@ defmodule Dataloader.EctoTest do
         ordered_usernames = Enum.map(loaded_posts, & &1.username)
 
         assert ordered_usernames == expected_usernames,
-               "got #{inspect(ordered_usernames)} but was expecting #{inspect(expected_usernames)} for sort_order #{sort_order}"
+               "got #{inspect(ordered_usernames)} but was expecting #{inspect(expected_usernames)} for sort_order #{
+                 sort_order
+               }"
       end
     end
 


### PR DESCRIPTION
In order to make dataloaders easier to use in test, I've added an `async?/1` function to the souurce protocol. In `async_safely/3` (which is now `async_safely/4`) we default to `async?: true` meaning this should be backwards compatible with any direct usage of that function. 

I've also added what would seem to me to be the proper default behavior for ecto and KV, which is that ecto will run synchronously if the repo is in a transaction, and KV is configurable at startup.

Feel free to tear it apart. This does seem pretty necessary for writing tests against absinthe in general, though :)

This is slightly orthoganal to #134 because its per-source

Addresses some if not all of #129