### PR TITLE
Adds batch telemetry event on the KV source

### DIFF
--- a/test/dataloader/ecto_test.exs
+++ b/test/dataloader/ecto_test.exs
@@ -57,7 +57,7 @@ defmodule Dataloader.EctoTest do
 
     :ok =
       :telemetry.attach_many(
-        "#{test}",
+        "#{__MODULE__}_#{test}",
         [
           [:dataloader, :source, :batch, :run, :start],
           [:dataloader, :source, :batch, :run, :stop]


### PR DESCRIPTION
These are the same telemetry events as for the Ecto source.
