### PR TITLE
Fix handling failed sources

### DIFF
--- a/test/dataloader_test.exs
+++ b/test/dataloader_test.exs
@@ -104,6 +104,22 @@ defmodule DataloaderTest do
     end
   end
 
+  describe "erroring sources" do
+    test "get/4 returns error" do
+      loader =
+        Dataloader.new(get_policy: :tuples, async: true)
+        |> Dataloader.add_source(:test, %Dataloader.Source.Error{})
+
+      result =
+        loader
+        |> Dataloader.load(:test, :sleep, 5)
+        |> Dataloader.run()
+        |> Dataloader.get(:test, :sleep, 5)
+
+      assert result == {:error, :killed}
+    end
+  end
+
   describe "get methods when configured to raise an error" do
     test "get/4 returns a value when successful", %{loader: loader} do
       result =

--- a/test/support/error_source.ex
+++ b/test/support/error_source.ex
@@ -1,0 +1,14 @@
+defmodule Dataloader.Source.Error do
+  defstruct []
+
+  defimpl Dataloader.Source do
+    def run(_source), do: Process.exit(self(), :kill)
+
+    def load(source, _batch_key, _item_key), do: source
+    def fetch(_source, _batch_key, _item_key), do: {:error, nil}
+    def pending_batches?(_source), do: true
+    def put(source, _batch_key, _item_key, _item), do: source
+    def timeout(_source), do: 1
+    def async?(_source), do: true
+  end
+end


### PR DESCRIPTION
When a source crashes, e.g. the process exits, dataloader currently stores the source under the name `:error`. Reading a key from a failed source thus raises an error such as:

```
** (RuntimeError) Source does not exist: :assoc

Registered sources are:

[:error]
```

## Approach

With this PR,

- a failed source is kept, as there might still be loaded data in it
- a separate field `failed_sources` in `Dataloader` stores which sources failed, and the reason
- `Dataloader.get/4` on a failed source first tries to fetch the key from the source. If that fails, the error for the entire source is returned instead of the individual key error
- failed sources are retried on next `Dataloader.run/1`

## Assumptions

- All sources are implemented in a way so that `Source.fetch` on a missing key returns an `error` tuple. Otherwise, `Dataloader.get/4` could first check whether a source failed and not call `Source.fetch` in this case, removing the ability to get previously (successfully) loaded data.
- Source failure does not need to be handled outside `Dataloader`. Otherwise, we could raise an exception, or make `Dataloader.run/1` return `ok`/`error` tuples, maybe when an option is set.
- Failed sources are retryable.

Please let me know what you think. If and when we merge this to `master`, I'd also be keen to open a PR targeting the `v1` branch 👍