### PR TITLE
Fixes rendering issue where comma is included with FB dataloader link

### DIFF
--- a/lib/dataloader.ex
+++ b/lib/dataloader.ex
@@ -8,7 +8,7 @@ defmodule Dataloader do
   # Dataloader
 
   Dataloader provides an easy way efficiently load data in batches. It's
-  inspired by https://github.com/facebook/dataloader, although it makes some
+  inspired by [https://github.com/facebook/dataloader](https://github.com/facebook/dataloader), although it makes some
   small API changes to better suit Elixir use cases.
 
   Central to Dataloader is the idea of a source. A single Dataloader struct can


### PR DESCRIPTION
Moduledocs automatically render links as HTML links and the comma was being tacked on, causing hexdocs to link to a broken url.

Thanks!

![output](https://user-images.githubusercontent.com/720877/232935105-03dc5798-9848-454e-9dba-393098951b47.gif)


