### PR TITLE
Fix join warning using Ecto 3.10.0+

### DIFF
--- a/lib/dataloader/ecto.ex
+++ b/lib/dataloader/ecto.ex
@@ -365,7 +365,7 @@ if Code.ensure_loaded?(Ecto) do
 
       results =
         from(input in subquery(inputs_query), as: :input)
-        |> join(:inner_lateral, q in subquery(inner_query))
+        |> join(:inner_lateral, [], q in subquery(inner_query), on: true)
         |> select([_input, q], q)
         |> repo.all(repo_opts)
 
@@ -728,6 +728,7 @@ if Code.ensure_loaded?(Ecto) do
           from(x in schema,
             as: :parent,
             inner_lateral_join: y in subquery(inner_query),
+            on: true,
             where: field(x, ^pk) in ^Enum.map(structs, &Map.get(&1, pk)),
             select: {field(x, ^pk), y}
           )


### PR DESCRIPTION
Since 3.10.0, Ecto warns when joining without `:on`:
> missing `:on` in join, defaulting to `on: true`.
